### PR TITLE
Changed tollerances to match original design

### DIFF
--- a/gridfinity-rebuilt-base.scad
+++ b/gridfinity-rebuilt-base.scad
@@ -190,7 +190,7 @@ module block_cutter(x,y,w,h,t,s) {
     
     v_len_tab = d_tabh;
     v_len_lip = d_wall2-d_wall+1.2;
-    v_cut_tab = d_tabh - (4*r_f1)/tan(a_tab); 
+    v_cut_tab = d_tabh - (2*r_f1)/tan(a_tab); 
     v_cut_lip = d_wall2-d_wall-d_clear;
     v_ang_tab = a_tab;
     v_ang_lip = 45;

--- a/gridfinity-rebuilt-base.scad
+++ b/gridfinity-rebuilt-base.scad
@@ -85,12 +85,10 @@ module profile_base() {
 module block_base() {
     translate([0,0,h_base])
     rounded_rectangle(gridx*length-0.5+0.002, gridy*length-0.5+0.002, h_bot/1.5, r_fo1/2+0.001);
-    
-    
-    // translate([0,0,h_base])
-    intersection(){
-        rounded_rectangle(gridx*length-0.5+0.002, gridy*length-0.5+0.002, h_base+h_bot/2, r_fo1/2+0.001);
 
+    intersection(){
+        translate([0,0,-1])
+        rounded_rectangle(gridx*length-0.5+0.005, gridy*length-0.5+0.005, h_base+h_bot/2*10, r_fo1/2+0.001);
         pattern_linear(gridx, gridy, length) 
         render()
         difference() {

--- a/gridfinity-rebuilt-base.scad
+++ b/gridfinity-rebuilt-base.scad
@@ -85,35 +85,42 @@ module profile_base() {
 module block_base() {
     translate([0,0,h_base])
     rounded_rectangle(gridx*length-0.5+0.002, gridy*length-0.5+0.002, h_bot/1.5, r_fo1/2+0.001);
-    pattern_linear(gridx, gridy, length) 
-    render()
-    difference() {
-        translate([0,0,h_base])
-        mirror([0,0,1])
-        union() {
-            hull() {
-                rounded_square(length-0.5-2*r_c2-2*r_c1, h_base, r_fo3/2);
-                rounded_square(length-0.5-2*r_c2, h_base-r_c1, r_fo2/2);
-            }
-            hull() {
-                rounded_square(length-0.5-2*r_c2, r_c2, r_fo2/2);
-                mirror([0,0,1])
-                rounded_square(length-0.5, h_bot/2, r_fo1/2);
-            }
-        }
-        
-        if (enable_holes)
-        pattern_circular(4) 
-        translate([d_hole/2, d_hole/2, 0]) {
+    
+    
+    // translate([0,0,h_base])
+    intersection(){
+        rounded_rectangle(gridx*length-0.5+0.002, gridy*length-0.5+0.002, h_base+h_bot/2, r_fo1/2+0.001);
+
+        pattern_linear(gridx, gridy, length) 
+        render()
+        difference() {
+            translate([0,0,h_base])
+            mirror([0,0,1])
             union() {
-                difference() {
-                    cylinder(h = 2*(h_hole+(enable_hole_slit?0.2:0)), r = r_hole2, center=true);
-                    if (enable_hole_slit)
-                    copy_mirror([0,1,0])
-                    translate([-1.5*r_hole2,r_hole1+0.1,h_hole]) 
-                    cube([r_hole2*3,r_hole2*3, 0.4]);
+                hull() {
+                    rounded_square(length-2*r_c2-2*r_c1, h_base, r_fo3/2);
+                    rounded_square(length-2*r_c2, h_base-r_c1, r_fo2/2);
                 }
-                cylinder(h = 3*h_base, r = r_hole1, center=true);
+                hull() {
+                    rounded_square(length-2*r_c2, r_c2, r_fo2/2);
+                    mirror([0,0,1])
+                    rounded_square(length, h_bot/2, r_fo1/2);
+                }
+            }
+            
+            if (enable_holes)
+            pattern_circular(4) 
+            translate([d_hole/2, d_hole/2, 0]) {
+                union() {
+                    difference() {
+                        cylinder(h = 2*(h_hole+(enable_hole_slit?0.2:0)), r = r_hole2, center=true);
+                        if (enable_hole_slit)
+                        copy_mirror([0,1,0])
+                        translate([-1.5*r_hole2,r_hole1+0.1,h_hole]) 
+                        cube([r_hole2*3,r_hole2*3, 0.4]);
+                    }
+                    cylinder(h = 3*h_base, r = r_hole1, center=true);
+                }
             }
         }
     }

--- a/gridfinity-rebuilt-base.scad
+++ b/gridfinity-rebuilt-base.scad
@@ -10,8 +10,8 @@ d_height = dht2-h_base;
 r_scoop = length*((d_height-2)/7+1)/12 - r_f2;  // scoop radius
 d_wall2 = r_base-r_c1-d_clear*sqrt(2);
 
-xl = gridx*length-2*d_wall+d_div; 
-yl = gridy*length-2*d_wall+d_div;
+xl = gridx*length-2*d_clear-2*d_wall+d_div; 
+yl = gridy*length-2*d_clear-2*d_wall+d_div;
 
 echo("=====");
 echo(height_total=d_height+h_base+(enable_lip?3.8:0));
@@ -191,7 +191,7 @@ module block_cutter(x,y,w,h,t,s) {
     v_len_tab = d_tabh;
     v_len_lip = d_wall2-d_wall+1.2;
     v_cut_tab = d_tabh - (4*r_f1)/tan(a_tab); 
-    v_cut_lip = d_wall2-d_wall;
+    v_cut_lip = d_wall2-d_wall-d_clear;
     v_ang_tab = a_tab;
     v_ang_lip = 45;
     

--- a/gridfinity-rebuilt-base.scad
+++ b/gridfinity-rebuilt-base.scad
@@ -10,8 +10,8 @@ d_height = dht2-h_base;
 r_scoop = length*((d_height-2)/7+1)/12 - r_f2;  // scoop radius
 d_wall2 = r_base-r_c1-d_clear*sqrt(2);
 
-xl = gridx*length-0.5-2*d_wall+d_div; 
-yl = gridy*length-0.5-2*d_wall+d_div;
+xl = gridx*length-2*d_wall+d_div; 
+yl = gridy*length-2*d_wall+d_div;
 
 echo("=====");
 echo(height_total=d_height+h_base+(enable_lip?3.8:0));
@@ -132,13 +132,13 @@ module profile_wall_sub() {
             [0,0],
             [d_wall/2,0],
             [d_wall/2,d_height-1.2-d_wall2+d_wall/2],
-            [d_wall2,d_height-1.2],
-            [d_wall2,d_height+h_base],
+            [d_wall2-d_clear,d_height-1.2],
+            [d_wall2-d_clear,d_height+h_base],
             [0,d_height+h_base]
         ]);
         color("red")
         offset(delta = 0.25) 
-        translate([r_base,d_height,0]) 
+        translate([r_base-d_clear,d_height,0])
         mirror([1,0,0]) 
         profile_base();
         square([d_wall,0]);
@@ -150,12 +150,12 @@ module profile_wall() {
     mirror([1,0,0])
     difference() {
         profile_wall_sub();
-        difference() {
+               difference() {
             translate([0, d_height+h_base-d_clear*sqrt(2), 0]) 
             circle(r_base/2);
             offset(r = r_f1) 
             offset(delta = -r_f1)
-            profile_wall_sub();
+                        profile_wall_sub();
         }
     }
 }
@@ -190,7 +190,7 @@ module block_cutter(x,y,w,h,t,s) {
     
     v_len_tab = d_tabh;
     v_len_lip = d_wall2-d_wall+1.2;
-    v_cut_tab = d_tabh - (2*r_f1)/tan(a_tab); 
+    v_cut_tab = d_tabh - (4*r_f1)/tan(a_tab); 
     v_cut_lip = d_wall2-d_wall;
     v_ang_tab = a_tab;
     v_ang_lip = 45;

--- a/gridfinity-rebuilt-base.scad
+++ b/gridfinity-rebuilt-base.scad
@@ -98,13 +98,13 @@ module block_base() {
             mirror([0,0,1])
             union() {
                 hull() {
-                    rounded_square(length-2*r_c2-2*r_c1, h_base, r_fo3/2);
-                    rounded_square(length-2*r_c2, h_base-r_c1, r_fo2/2);
+                    rounded_square(length-0.05-2*r_c2-2*r_c1, h_base, r_fo3/2);
+                    rounded_square(length-0.05-2*r_c2, h_base-r_c1, r_fo2/2);
                 }
                 hull() {
-                    rounded_square(length-2*r_c2, r_c2, r_fo2/2);
+                    rounded_square(length-0.05-2*r_c2, r_c2, r_fo2/2);
                     mirror([0,0,1])
-                    rounded_square(length, h_bot/2, r_fo1/2);
+                    rounded_square(length-0.05, h_bot/2, r_fo1/2);
                 }
             }
             

--- a/gridfinity-rebuilt.scad
+++ b/gridfinity-rebuilt.scad
@@ -64,7 +64,7 @@ r_hole2 = 3.25; // magnet hole radius
 d_hole = 26;    // center-to-center distance between holes
 h_hole = 2.4;   // magnet hole depth
 
-r_f1 = 0.6;     // top edge fillet radius
+r_f1 = 0.3;     // top edge fillet radius
 r_f2 = 2.8;     // internal fillet radius
 
 d_div = 1.2;    // width of divider between compartments

--- a/gridfinity-rebuilt.scad
+++ b/gridfinity-rebuilt.scad
@@ -64,7 +64,7 @@ r_hole2 = 3.25; // magnet hole radius
 d_hole = 26;    // center-to-center distance between holes
 h_hole = 2.4;   // magnet hole depth
 
-r_f1 = 0.3;     // top edge fillet radius
+r_f1 = 0.6;     // top edge fillet radius
 r_f2 = 2.8;     // internal fillet radius
 
 d_div = 1.2;    // width of divider between compartments


### PR DESCRIPTION
First of all, thank you for your work. This project is awesome.


When printing my first bin, I noticed that individual grid block_base had more clearance. I changed the module slightly.

At first, the clearance of 0.5 mm was added to all sides of the individual grids of the block_base (before a pattern is created).

My changes add the 0.5 mm clearance of the already assembled block_base (after the pattern is created).

The change results in the same block_base as in the original design by Zack

Note: Due to change in indentation, Github messed up the diff. VScode does it way better 
