### PR TITLE
screw-together baseplates

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -30,7 +30,7 @@ d_screw_head = 5;
 // screw spacing distance
 screw_spacing = .5;
 // number of screws per grid block
-n_screws = 2; // [1:3]
+n_screws = 1; // [1:3]
 
 
 /* [Fit to Drawer] */


### PR DESCRIPTION
This creates a version of the skeletonized baseplate with horizontal holes suitable for attaching baseplates together using screws and nuts. Default values are appropriate for M3 or 4-40 screws.  I added a new baseplate type called "screw-together."  

I had thought of making this just a checkbox to turn on screw-together functionality, but since it ONLY works with the skeletonized baseplate type, I thought that would be confusing.  This code just builds the skeletonized baseplate as usual and then adds the screw together holes at the end.

This creates  equivalent functionality to the baseplate Zack highlighted in his most recent video ( https://www.youtube.com/watch?v=7FCwMq-rVsY Store Anything Anywhere with Gridfinity! 20+ Weird Printable Organizers by Makers Like You! ) - Kyle Warren's Screw-Together Baseplate ( https://www.printables.com/model/300603-gridfinity-screw-together-baseplate )