### PR TITLE
Make scoop radius customizable

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -26,7 +26,6 @@ https://github.com/kennetek/gridfinity-rebuilt-openscad
 /* [Setup Parameters] */
 $fa = 8;
 $fs = 0.25;
-$scoop_percentage = 100;
 
 /* [General Settings] */
 // number of bases along x-axis
@@ -45,8 +44,6 @@ divx = 1;
 divy = 1;
 
 /* [Toggles] */
-// internal fillet for easy part removal
-enable_scoop = true;
 // snap gridz height to nearest 7mm increment
 enable_zsnap = false;
 // enable upper lip for stacking other bins
@@ -57,6 +54,8 @@ enable_lip = true;
 gridz_define = 0; // [0:gridz is the height of bins in units of 7mm increments - Zack's method,1:gridz is the internal height in millimeters, 2:gridz is the overall external height of the bin in millimeters]
 // the type of tabs
 style_tab = 1; //[0:Full,1:Auto,2:Left,3:Center,4:Right,5:None]
+// scoop weight percentage. 0 disables scoop, 1 is regualar scoop. Any real number will scale the effective scoop. 
+scoop = 1;
 
 // overrides internal block height of bin (for solid containers). Leave zero for default height. Units: mm
 height_internal = 0; 
@@ -72,14 +71,14 @@ div_base_y = 0;
 
 // ===== IMPLEMENTATION ===== //
 
-color("tomato") {
-gridfinityInit(gridx, gridy, height(gridz, gridz_define, enable_lip, enable_zsnap), height_internal, length) {
-
-    cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, enable_scoop = enable_scoop);
-}
-gridfinityBase(gridx, gridy, length, div_base_x, div_base_y, style_hole);
-
-}
+//color("tomato") {
+//gridfinityInit(gridx, gridy, height(gridz, gridz_define, enable_lip, enable_zsnap), height_internal, length) {
+//
+//    cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop);
+//}
+//gridfinityBase(gridx, gridy, length, div_base_x, div_base_y, style_hole);
+//
+//}
 
 
 // ===== EXAMPLES ===== //

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -71,14 +71,14 @@ div_base_y = 0;
 
 // ===== IMPLEMENTATION ===== //
 
-//color("tomato") {
-//gridfinityInit(gridx, gridy, height(gridz, gridz_define, enable_lip, enable_zsnap), height_internal, length) {
-//
-//    cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop);
-//}
-//gridfinityBase(gridx, gridy, length, div_base_x, div_base_y, style_hole);
-//
-//}
+color("tomato") {
+gridfinityInit(gridx, gridy, height(gridz, gridz_define, enable_lip, enable_zsnap), height_internal, length) {
+
+    cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop);
+}
+gridfinityBase(gridx, gridy, length, div_base_x, div_base_y, style_hole);
+
+}
 
 
 // ===== EXAMPLES ===== //

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -26,6 +26,7 @@ https://github.com/kennetek/gridfinity-rebuilt-openscad
 /* [Setup Parameters] */
 $fa = 8;
 $fs = 0.25;
+$scoop_percentage = 100;
 
 /* [General Settings] */
 // number of bases along x-axis

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -346,7 +346,7 @@ module fillet_cutter(t = 0, c = "goldenrod") {
 }
 
 module profile_cutter(h, l, s) {
-    scoop = s ? (length*(($dh-2)/7+1)/12-r_f2) : 0; 
+    scoop = s ? (length*(($dh * ($scoop_percentage / 100)-2)/7+1)/12-r_f2) : 0; 
     translate([r_f2,r_f2])
     hull() {
         if (l-scoop-2*r_f2 > 0)

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -15,11 +15,11 @@ function height (z,d=0,l=true,s=true) = (s?((abs(hf(z,d,l))%7==0)?hf(z,d,l):hf(z
 // n_divy:  number of y compartments (ideally, coprime w/ gridy) 
 //          set n_div values to 0 for a solid bin 
 // style_tab:   tab style for all compartments. see cut()
-// enable_scoop:    scoop toggle for all compartments. see cut()
-module cutEqual(n_divx=1, n_divy=1, style_tab=1, enable_scoop=true) {
+// scoop_weight:    scoop toggle for all compartments. see cut()
+module cutEqual(n_divx=1, n_divy=1, style_tab=1, scoop_weight=1) {
     for (i = [1:n_divx]) 
     for (j = [1:n_divy])
-    cut((i-1)*$gxx/n_divx,(j-1)*$gyy/n_divy, $gxx/n_divx, $gyy/n_divy, style_tab, enable_scoop);
+    cut((i-1)*$gxx/n_divx,(j-1)*$gyy/n_divy, $gxx/n_divx, $gyy/n_divy, style_tab, scoop_weight);
 }
 
 // initialize gridfinity
@@ -53,7 +53,7 @@ module gridfinityInit(gx, gy, h, h0 = 0, l) {
 //      0:full, 1:auto, 2:left, 3:center, 4:right, 5:none
 //      Automatic alignment will use left tabs for bins on the left edge, right tabs for bins on the right edge, and center tabs everywhere else. 
 // s:   toggle the rounded back corner that allows for easy removal
-module cut(x=0, y=0, w=1, h=1, t=1, s=true) {
+module cut(x=0, y=0, w=1, h=1, t=1, s=1) {
     translate([0,0,-$dh-h_base])
     cut_move(x,y,w,h)
     block_cutter(clp(x,0,$gxx), clp(y,0,$gyy), clp(w,0,$gxx-x), clp(h,0,$gyy-y), t, s);
@@ -232,7 +232,7 @@ module block_cutter(x,y,w,h,t,s) {
     xlen = w*($gxx*length+d_magic)/$gxx-d_div; 
     
     height = $dh;
-    extent = (s && ycutfirst ? d_wall2-d_wall-d_clear : 0); 
+    extent = (abs(s) > 0 && ycutfirst ? d_wall2-d_wall-d_clear : 0); 
     tab = (zsmall || t == 5) ? (ycutlast?v_len_lip:0) : v_len_tab; 
     ang = (zsmall || t == 5) ? (ycutlast?v_ang_lip:0) : v_ang_tab;
     cut = (zsmall || t == 5) ? (ycutlast?v_cut_lip:0) : v_cut_tab;
@@ -298,7 +298,7 @@ module block_cutter(x,y,w,h,t,s) {
             if (!((zsmall || t == 5) && !ycutlast))
             profile_cutter_tab(height-h_bot, tab, ang);
             
-            if (!s && y == 0)
+            if (!(abs(s) > 0)&& y == 0)
             translate([ylen-extent,0,0])
             mirror([1,0,0])
             profile_cutter_tab(height-h_bot, v_len_lip, v_ang_lip);
@@ -346,7 +346,7 @@ module fillet_cutter(t = 0, c = "goldenrod") {
 }
 
 module profile_cutter(h, l, s) {
-    scoop = s ? (length*(($dh * ($scoop_percentage / 100)-2)/7+1)/12-r_f2) : 0; 
+    scoop = max(s*$dh/2-r_f2,0); 
     translate([r_f2,r_f2])
     hull() {
         if (l-scoop-2*r_f2 > 0)


### PR DESCRIPTION
I wanted to maximize the space inside my bins as well as making them faster to print and use less plastic.
I found that having a scoop is an absolute must for small parts in small bins, but at the same time it doesn't need to be a huge one like the default design. As long as the corner of the box is not a hard 90° pretty small spoons work fairly well.

I am now printing my boxes with a spoon 25% of the original and I'm find it almost as confortable as the 100% one. I made it a customizable parameter. I attach some screenshots.

#### 100% spoon radius (the default)
![Screenshot 2023-01-31 at 20 55 41](https://user-images.githubusercontent.com/265339/215869639-661c5004-a7bf-4d11-bbe8-6a07efcfe20f.jpg)

#### 50% spoon radius (works just as well as the original for me
![Screenshot 2023-01-31 at 20 55 54](https://user-images.githubusercontent.com/265339/215869654-76138ef3-e274-4800-9843-f2d465b64c93.jpg)

#### 25% spoon radius (works _almost_ as well as the original, but good enough for me)
![Screenshot 2023-01-31 at 20 56 08](https://user-images.githubusercontent.com/265339/215869651-11f34155-e75f-4100-b7d9-071869a1e153.jpg)

You can also put values over 100% for a bigger radius if you really want.
