### PR TITLE
improve performance

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -16,9 +16,9 @@ $fs = 0.25;
 
 /* [General Settings] */
 // number of bases along x-axis
-gridx = 4;  
+gridx = 5;  
 // number of bases along y-axis   
-gridy = 4;  
+gridy = 5;  
 // base unit
 length = 42;
 
@@ -91,6 +91,7 @@ module gridfinityBaseplate(gridx, gridy, length, dix, diy, sp, sm, sh, fitx, fit
         rounded_rectangle(dx*2, dy*2, h_base*2, r_base);
         
         pattern_linear(gx, gy, length) {
+            render() {
             if (sm) block_base_hole(1);
 
             if (sp == 1)
@@ -106,6 +107,7 @@ module gridfinityBaseplate(gridx, gridy, length, dix, diy, sp, sm, sh, fitx, fit
             translate([0,0,-off]) { 
                 if (sh == 1) cutter_countersink();
                 else if (sh == 2) cutter_counterbore();
+            }
             }
         }
         if (sp == 3 || sp ==4) cutter_screw_together(gx, gy, off);    

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -29,9 +29,9 @@ $fs = 0.25;
 
 /* [General Settings] */
 // number of bases along x-axis
-gridx = 1;  
+gridx = 5;  
 // number of bases along y-axis   
-gridy = 1;  
+gridy = 5;  
 // bin height. See bin height information and "gridz_define" below.  
 gridz = 6;   
 // base unit

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -97,22 +97,25 @@ module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true) {
         translate([0,0,-1])
         rounded_rectangle(xx+0.005, yy+0.005, h_base+h_bot/2*10, r_fo1/2+0.001);
         
-        render()
-        difference() {
-            pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l) 
-            block_base_solid(dbnx, dbny, l, off);
-            
-            if (style_hole > 0) 
-                if (style_hole % p_corn < 0.001)
-                pattern_linear(2, 2, (gx-1)*length+d_hole, (gy-1)*length+d_hole)
-                block_base_hole(style_hole / p_corn, off);
-                else
-                pattern_linear(gx, gy, l)
-                pattern_circular(abs(d_hole)<0.001?1:4) 
-                translate([d_hole/2, d_hole/2, 0])
-                block_base_hole(style_hole, off);
-        }
+        pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l) 
+        block_base(gx, gy, l, dbnx, dbny, style_hole, off);
     }
+}
+
+module block_base(gx, gy, l, dbnx, dbny, style_hole, off) {
+    render()
+    difference() {
+        block_base_solid(dbnx, dbny, l, off);
+        
+        if (style_hole > 0) 
+            if (style_hole % p_corn < 0.001)
+            pattern_linear(2, 2, (gx-1)*length+d_hole, (gy-1)*length+d_hole)
+            block_base_hole(style_hole / p_corn, off);
+            else
+            pattern_circular(abs(d_hole)<0.001?1:4) 
+            translate([d_hole/2, d_hole/2, 0])
+            block_base_hole(style_hole, off);
+        }
 }
 
 module block_base_solid(dbnx, dbny, l, o) { 


### PR DESCRIPTION
I noticed the performance of the rendering in preview mode with default values was lacking, even with fast csg. The generation of a 5x5 bin took more than a minute. 20 x 20 base plates was a no go without crashing (I am not able to print it anyway :)).

When measuring the performance, I started rendering with a 1x1 grid and changed it to 5x5 without closing the UI. I managed to cut the time of a 5x5 bin by ~90%.

There are more ways to improve performance, but this is the biggest one which will have impact on every rebuild model (except for vase mode as it does not need a lot of base grids)

The changes in this pull request (first commit) have improved the performance as following

 ## generate bin before change 1x1 to 5x5
OpenSCAD 2023.01.25 
https://www.openscad.org/
 
Copyright (C) 2009-2022 The OpenSCAD Developers
This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad-kennetek/gridfinity-rebuilt-bins.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 109
Geometry cache size in bytes: 1261752
CGAL Polyhedrons in cache: 18
CGAL cache size in bytes: 682464
Compiling design (CSG Products normalization)...
Normalized tree has 14 elements!
Compile and preview finished.
Total rendering time: 0:00:04.466
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad-kennetek/gridfinity-rebuilt-bins.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 191
Geometry cache size in bytes: 9575512
CGAL Polyhedrons in cache: 84
CGAL cache size in bytes: 15576760
Compiling design (CSG Products normalization)...
Normalized tree has 16 elements!
Compile and preview finished.
Total rendering time: 0:01:06.791

## generate bin after change 1x1 to 5x5

OpenSCAD 2023.01.25 
https://www.openscad.org/
 
Copyright (C) 2009-2022 The OpenSCAD Developers
This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad/gridfinity-rebuilt-bins.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 109
Geometry cache size in bytes: 1261752
CGAL Polyhedrons in cache: 14
CGAL cache size in bytes: 437312
Compiling design (CSG Products normalization)...
Normalized tree has 14 elements!
Compile and preview finished.
Total rendering time: 0:00:04.348
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad/gridfinity-rebuilt-bins.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 190
Geometry cache size in bytes: 2483360
CGAL Polyhedrons in cache: 17
CGAL cache size in bytes: 443584
Compiling design (CSG Products normalization)...
Normalized tree has 64 elements!
Compile and preview finished.
Total rendering time: 0:00:05.976

## generate baseplate before change 1x1 to 5x5
OpenSCAD 2023.01.25 
https://www.openscad.org/
 
Copyright (C) 2009-2022 The OpenSCAD Developers
This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad-kennetek/gridfinity-rebuilt-baseplate.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 30
Geometry cache size in bytes: 204504
CGAL Polyhedrons in cache: 6
CGAL cache size in bytes: 84336
Compiling design (CSG Products normalization)...
Normalized tree has 44 elements!
Compile and preview finished.
Total rendering time: 0:00:00.207
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad-kennetek/gridfinity-rebuilt-baseplate.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 39
Geometry cache size in bytes: 1430944
CGAL Polyhedrons in cache: 38
CGAL cache size in bytes: 2218960
Compiling design (CSG Products normalization)...
Normalized tree has 1028 elements!
Compile and preview finished.
Total rendering time: 0:00:05.843

## generate baseplate after change 1x1 to 5x5

OpenSCAD 2023.01.25 
https://www.openscad.org/
 
Copyright (C) 2009-2022 The OpenSCAD Developers
This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad/gridfinity-rebuilt-baseplate.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 36
Geometry cache size in bytes: 546544
CGAL Polyhedrons in cache: 13
CGAL cache size in bytes: 464184
Compiling design (CSG Products normalization)...
Normalized tree has 4 elements!
Compile and preview finished.
Total rendering time: 0:00:01.262
Loaded design '/home/ruud/git/gridfinity-rebuilt-openscad/gridfinity-rebuilt-baseplate.scad'.
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
Geometries in cache: 44
Geometry cache size in bytes: 576192
CGAL Polyhedrons in cache: 13
CGAL cache size in bytes: 464184
Compiling design (CSG Products normalization)...
Normalized tree has 52 elements!
Compile and preview finished.
Total rendering time: 0:00:00.289