### PR TITLE
Add support for indented bottom to save filament

### DIFF
--- a/gridfinity-constants.scad
+++ b/gridfinity-constants.scad
@@ -16,6 +16,11 @@ r_fo2 = 3.2;
 // outside radii 3
 r_fo3 = 1.6; 
 
+// bottom indent offset
+d_indent = 1.6;
+// bottom indent height
+h_indent = 4.68;
+
 // screw hole radius
 r_hole1 = 1.5;  
 // magnet hole radius

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -62,7 +62,7 @@ scoop = 1; //[0:0.1:1]
 style_corners = false;
 
 /* [Base] */
-style_hole = 3; // [0:no holes, 1:magnet holes only, 2: magnet and screw holes - no printable slit, 3: magnet and screw holes - printable slit]
+style_hole = 3; // [0:no holes, 1:magnet holes only, 2: magnet and screw holes - no printable slit, 3: magnet and screw holes - printable slit, 4: indented bottom (use bridging)]
 // number of divisions per 1 unit of base along the X axis. (default 1, only use integers. 0 means automatically guess the right division)
 div_base_x = 0;
 // number of divisions per 1 unit of base along the Y axis. (default 1, only use integers. 0 means automatically guess the right division)

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -101,8 +101,11 @@ module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true) {
         difference() {
             pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l) 
             block_base_solid(dbnx, dbny, l, off);
-            
-            if (style_hole > 0) 
+
+            if (style_hole == 4)
+            pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l)
+            block_base_indent(dbnx, dbny, l, off);
+            else if (style_hole > 0) 
                 if (style_hole % p_corn < 0.001)
                 pattern_linear(2, 2, (gx-1)*length+d_hole, (gy-1)*length+d_hole)
                 block_base_hole(style_hole / p_corn, off);
@@ -133,6 +136,15 @@ module block_base_solid(dbnx, dbny, l, o) {
             rounded_rectangle(xx+o, yy+o, h_bot/2+abs(10*o), r_fo1/2);
         }
     }
+}
+
+module block_base_indent(dbnx, dbny, l, o) { 
+    xx = dbnx*l-0.05; 
+    yy = dbny*l-0.05; 
+    oo = (o/2)*(sqrt(2)-1);
+    translate([0,0,h_indent])
+    mirror([0,0,1])
+    rounded_rectangle(xx-2*r_c2-2*r_c1-2*d_indent+o, yy-2*r_c2-2*r_c1-2*d_indent+o, h_indent+oo, r_fo3/2);
 }
 
 module block_base_hole(style_hole, o=0) {


### PR DESCRIPTION
Adds support for indented bottoms for bins by setting `style_hole` to 4. Indented bottoms reduce the amount of filament required to print bins. Does require your slicer to support bridging.

Here's an example of the bottom of a 1x2x4 bin printed with this option:
![image](https://user-images.githubusercontent.com/1434399/221386454-bd3add54-73d5-4e20-9e3f-1d9dd15f1788.png)
![image](https://user-images.githubusercontent.com/1434399/221386511-11727149-8f6b-4745-b604-07d74fe6078a.png)
