### PR TITLE
Fix ghosted hole cutout rendering

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -92,7 +92,7 @@ module gridfinityBaseplate(gridx, gridy, length, dix, diy, sp, sm, sh, fitx, fit
         rounded_rectangle(dx*2, dy*2, h_base*2, r_base);
         
         pattern_linear(gx, gy, length) {
-            render() {
+            render(convexity = 6) {
                 if (sm) block_base_hole(1);
 
                 if (sp == 1)

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -103,7 +103,7 @@ module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true) {
 }
 
 module block_base(gx, gy, l, dbnx, dbny, style_hole, off) {
-    render()
+    render(convexity = 2)
     difference() {
         block_base_solid(dbnx, dbny, l, off);
         


### PR DESCRIPTION
**Changes summary:**
- Add `render(convexity=)` argument so negative volumes render properly in preview mode

**Base:**
Before
![ghostedBase](https://user-images.githubusercontent.com/6081511/233817020-39263b21-b99d-40f5-8172-c48e25bf913a.png)
After
![nonghostedBase](https://user-images.githubusercontent.com/6081511/233817295-a7fc3485-67b7-4a05-bb82-a0c100101a76.png)

**Bin:**
Before
![ghostedBin](https://user-images.githubusercontent.com/6081511/233817021-bfdc3ae7-9fce-4515-ba05-f5cab356ebd7.png)
After
![nonghostedBin](https://user-images.githubusercontent.com/6081511/233817024-d4eb3ed8-1daf-4709-af75-4c6dc658f46d.png)

