### PR TITLE
remove square with zero height call

### DIFF
--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -174,7 +174,6 @@ module profile_wall_sub() {
         translate([r_base-d_clear,$dh,0])
         mirror([1,0,0]) 
         profile_base();
-        square([d_wall,0]);
     }
 }
 


### PR DESCRIPTION
fixes #116 

Current code base contains a `square` call with height= 0. This results in nothing. Opensad is fine with it unless BOSL2 is used. I removed the call. 