### PR TITLE
Add option for brim ears in the corners

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -65,6 +65,8 @@ style_hole = 3; // [0:no holes, 1:magnet holes only, 2: magnet and screw holes -
 div_base_x = 0;
 // number of divisions per 1 unit of base along the Y axis. (default 1, only use integers. 0 means automatically guess the right division)
 div_base_y = 0; 
+// add brim in the corner to help with warping/lifting
+with_brim = false;
 
 
 
@@ -76,7 +78,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
     if (divx > 0 && divy > 0)
     cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop);
 }
-gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners);
+gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners, with_brim=with_brim);
 
 }
 

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -80,13 +80,16 @@ module profile_base() {
     ]);
 }
 
-module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only_corners=false) {
+module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only_corners=false, with_brim=false) {
     dbnxt = [for (i=[1:5]) if (abs(gx*i)%1 < 0.001 || abs(gx*i)%1 > 0.999) i];
     dbnyt = [for (i=[1:5]) if (abs(gy*i)%1 < 0.001 || abs(gy*i)%1 > 0.999) i];
     dbnx = 1/(dx==0 ? len(dbnxt) > 0 ? dbnxt[0] : 1 : round(dx));
     dbny = 1/(dy==0 ? len(dbnyt) > 0 ? dbnyt[0] : 1 : round(dy));
     xx = gx*l-0.5;
     yy = gy*l-0.5;
+    
+    if (with_brim)
+    brim(gx*l/2, gy*l/2)
     
     if (final_cut)
     translate([0,0,h_base])
@@ -457,3 +460,10 @@ module sweep_rounded(w=10, h=10) {
     }
 }
 
+module brim(x, y, height=0.3, diameter=10) {
+    linear_extrude(height)
+    pattern_circular(2)
+    copy_mirror()
+    translate([x, y])
+    circle(diameter);
+}


### PR DESCRIPTION
Add an option to add brim ears in the corners to help with warping/lifting. 

This helps when printing larger boxes.

![image](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/4105421/59e8f269-94a5-454d-8654-4512262f0053)

(This is my first time writing in OpenSCAD, feel free to comment on the code or structure).