### PR TITLE
Add option for a chamfered magnet holes

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -72,6 +72,8 @@ style_lip = 0; //[0: Regular lip, 1:remove lip subtractively, 2: remove lip and 
 scoop = 1; //[0:0.1:1]
 // only cut magnet/screw holes at the corners of the bin to save uneccesary print time
 only_corners = false;
+// chamfer out magnet holes for easier magnet insertion
+chamfer_holes = true;
 
 /* [Base] */
 style_hole = 4; // [0:no holes, 1:magnet holes only, 2: magnet and screw holes - no printable slit, 3: magnet and screw holes - printable slit, 4: Gridfinity Refined hole - no glue needed]
@@ -96,7 +98,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
         cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation);
     }
 }
-gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners);
+gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners, chamfer_holes=chamfer_holes);
 }
 
 

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -72,8 +72,8 @@ style_lip = 0; //[0: Regular lip, 1:remove lip subtractively, 2: remove lip and 
 scoop = 1; //[0:0.1:1]
 // only cut magnet/screw holes at the corners of the bin to save uneccesary print time
 only_corners = false;
-// chamfer out magnet holes for easier magnet insertion
-chamfer_holes = true;
+// chamfer out magnet holes for easier magnet insertion. Set to 0 to disable chamfer
+hole_chamfer = 0.8;
 
 /* [Base] */
 style_hole = 4; // [0:no holes, 1:magnet holes only, 2: magnet and screw holes - no printable slit, 3: magnet and screw holes - printable slit, 4: Gridfinity Refined hole - no glue needed]
@@ -98,7 +98,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
         cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation);
     }
 }
-gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners, chamfer_holes=chamfer_holes);
+gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners, hole_chamfer=hole_chamfer);
 }
 
 

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -113,7 +113,7 @@ module profile_base() {
     ]);
 }
 
-module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only_corners=false, chamfer_holes=false) {
+module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only_corners=false, hole_chamfer=0.0) {
     dbnxt = [for (i=[1:5]) if (abs(gx*i)%1 < 0.001 || abs(gx*i)%1 > 0.999) i];
     dbnyt = [for (i=[1:5]) if (abs(gy*i)%1 < 0.001 || abs(gy*i)%1 > 0.999) i];
     dbnx = 1/(dx==0 ? len(dbnxt) > 0 ? dbnxt[0] : 1 : round(dx));
@@ -133,19 +133,19 @@ module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only
         if(only_corners) {
                 difference(){
                 pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l)
-                block_base(gx, gy, l, dbnx, dbny, 0, off, chamfer_holes);
+                block_base(gx, gy, l, dbnx, dbny, 0, off, hole_chamfer);
                 pattern_linear(2, 2, (gx-1)*l_grid+d_hole, (gy-1)*l_grid+d_hole)
-                block_base_hole(style_hole, off, chamfer_holes);
+                block_base_hole(style_hole, off, hole_chamfer);
             }
         }
         else {
             pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l)
-            block_base(gx, gy, l, dbnx, dbny, style_hole, off, chamfer_holes);
+            block_base(gx, gy, l, dbnx, dbny, style_hole, off, hole_chamfer);
         }
     }
 }
 
-module block_base(gx, gy, l, dbnx, dbny, style_hole, off, chamfer_holes) {
+module block_base(gx, gy, l, dbnx, dbny, style_hole, off, hole_chamfer) {
     render(convexity = 2)
     difference() {
         block_base_solid(dbnx, dbny, l, off);
@@ -157,7 +157,7 @@ module block_base(gx, gy, l, dbnx, dbny, style_hole, off, chamfer_holes) {
                 refined_hole();
             else
                 translate([l/2-d_hole_from_side, l/2-d_hole_from_side, 0])
-                block_base_hole(style_hole, off, chamfer_holes);
+                block_base_hole(style_hole, off, hole_chamfer);
         }
 }
 
@@ -181,7 +181,7 @@ module block_base_solid(dbnx, dbny, l, o) {
     }
 }
 
-module block_base_hole(style_hole, o=0, chamfer=true) {
+module block_base_hole(style_hole, o=0, chamfer=0.0) {
     r1 = r_hole1-o/2;
     r2 = r_hole2-o/2;
 
@@ -199,10 +199,10 @@ module block_base_hole(style_hole, o=0, chamfer=true) {
         if (style_hole > 1)
         cylinder(h = 2*h_base-o, r = r1, center=true);
         // generate an offset pyramid for a 0.4mm chamfer
-        if (chamfer)
+        if (chamfer>0)
         translate([0, 0, (hole_h-0.01)])
         difference() {
-            cylinder(h = 2*(h_hole-o+(style_hole==3?h_slit:0)), r1 = r2 + 0.4, r2 = 0.0001, center=true);
+            cylinder(h = 2*(h_hole-o+(style_hole==3?h_slit:0)), r1 = r2 + chamfer, r2 = 0.0001, center=true);
             translate([0, 0, (hole_h)/2])
             cylinder(h = hole_h, r=r2,center=true);
         }

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -196,7 +196,7 @@ module block_base_hole(style_hole, o=0, chamfer=0.0) {
         }
         if (style_hole > 1)
         cylinder(h = 2*h_base-o, r = r1, center=true);
-        // generate an offset pyramid for a 0.4mm chamfer
+        // generate an offset cone for a 0.4mm chamfer
         if (chamfer>0)
         translate([0, 0, (hole_h-0.01)])
         difference() {

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -200,7 +200,7 @@ module block_base_hole(style_hole, o=0, chamfer=0.0) {
         if (chamfer>0)
         translate([0, 0, (hole_h-0.01)])
         difference() {
-            cylinder(h = 2*(h_hole-o+(style_hole==3?h_slit:0)), r1 = r2 + chamfer, r2 = 0.0001, center=true);
+            cylinder(h = 2*hole_h, r1 = r2 + chamfer, r2 = 0.0001, center=true);
             translate([0, 0, (hole_h)/2])
             cylinder(h = hole_h, r=r2,center=true);
         }

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -181,12 +181,15 @@ module block_base_solid(dbnx, dbny, l, o) {
     }
 }
 
-module block_base_hole(style_hole, o=0) {
+module block_base_hole(style_hole, o=0, chamfer=true) {
     r1 = r_hole1-o/2;
     r2 = r_hole2-o/2;
+
+    hole_h = h_hole-o+(style_hole==3?h_slit:0);
+
     union() {
         difference() {
-            cylinder(h = 2*(h_hole-o+(style_hole==3?h_slit:0)), r=r2, center=true);
+            cylinder(h = 2*(hole_h), r=r2, center=true);
 
             if (style_hole==3)
             copy_mirror([0,1,0])
@@ -195,9 +198,16 @@ module block_base_hole(style_hole, o=0) {
         }
         if (style_hole > 1)
         cylinder(h = 2*h_base-o, r = r1, center=true);
+        // generate an offset pyramid for a 0.4mm chamfer
+        if (chamfer)
+        translate([0, 0, (hole_h-0.01)])
+        difference() {
+            cylinder(h = 2*(h_hole-o+(style_hole==3?h_slit:0)), r1 = r2 + 0.4, r2 = 0.0001, center=true);
+            translate([0, 0, (hole_h)/2])
+            cylinder(h = hole_h, r=r2,center=true);
+        }
     }
 }
-
 
 module refined_hole() {
     /**

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -113,7 +113,7 @@ module profile_base() {
     ]);
 }
 
-module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only_corners=false) {
+module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only_corners=false, chamfer_holes=false) {
     dbnxt = [for (i=[1:5]) if (abs(gx*i)%1 < 0.001 || abs(gx*i)%1 > 0.999) i];
     dbnyt = [for (i=[1:5]) if (abs(gy*i)%1 < 0.001 || abs(gy*i)%1 > 0.999) i];
     dbnx = 1/(dx==0 ? len(dbnxt) > 0 ? dbnxt[0] : 1 : round(dx));
@@ -133,19 +133,19 @@ module gridfinityBase(gx, gy, l, dx, dy, style_hole, off=0, final_cut=true, only
         if(only_corners) {
                 difference(){
                 pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l)
-                block_base(gx, gy, l, dbnx, dbny, 0, off);
+                block_base(gx, gy, l, dbnx, dbny, 0, off, chamfer_holes);
                 pattern_linear(2, 2, (gx-1)*l_grid+d_hole, (gy-1)*l_grid+d_hole)
-                block_base_hole(style_hole, off);
+                block_base_hole(style_hole, off, chamfer_holes);
             }
         }
         else {
             pattern_linear(gx/dbnx, gy/dbny, dbnx*l, dbny*l)
-            block_base(gx, gy, l, dbnx, dbny, style_hole, off);
+            block_base(gx, gy, l, dbnx, dbny, style_hole, off, chamfer_holes);
         }
     }
 }
 
-module block_base(gx, gy, l, dbnx, dbny, style_hole, off) {
+module block_base(gx, gy, l, dbnx, dbny, style_hole, off, chamfer_holes) {
     render(convexity = 2)
     difference() {
         block_base_solid(dbnx, dbny, l, off);
@@ -157,7 +157,7 @@ module block_base(gx, gy, l, dbnx, dbny, style_hole, off) {
                 refined_hole();
             else
                 translate([l/2-d_hole_from_side, l/2-d_hole_from_side, 0])
-                block_base_hole(style_hole, off);
+                block_base_hole(style_hole, off, chamfer_holes);
         }
 }
 

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -184,9 +184,7 @@ module block_base_solid(dbnx, dbny, l, o) {
 module block_base_hole(style_hole, o=0, chamfer=0.0) {
     r1 = r_hole1-o/2;
     r2 = r_hole2-o/2;
-
     hole_h = h_hole-o+(style_hole==3?h_slit:0);
-
     union() {
         difference() {
             cylinder(h = 2*(hole_h), r=r2, center=true);

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -196,7 +196,7 @@ module block_base_hole(style_hole, o=0, chamfer=0.0) {
         }
         if (style_hole > 1)
         cylinder(h = 2*h_base-o, r = r1, center=true);
-        // generate an offset cone for a 0.4mm chamfer
+        // generate an offset cone for a chamfer
         if (chamfer>0)
         translate([0, 0, (hole_h-0.01)])
         difference() {


### PR DESCRIPTION
Adds a customisable chamfer (defaults to 0.8mm) to the magnet holes. This counteracts any elephant's foot and makes magnet insertion easier in all cases (basically makes glue mandatory, though).

Works for all circular magnet holes, and with `only_corners`.

Set to 0 to disable.