### PR TITLE
Set bin height to 1mm

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -58,8 +58,8 @@ c_depth = 1;
 /* [Height] */
 // determine what the variable "gridz" applies to based on your use case
 gridz_define = 0; // [0:gridz is the height of bins in units of 7mm increments - Zack's method,1:gridz is the internal height in millimeters, 2:gridz is the overall external height of the bin in millimeters]
-// overrides internal block height of bin (for solid containers). Leave zero for default height. Units: mm
-height_internal = 0;
+// overrides internal block height of bin (for solid containers). Set to zero for default height. Units: mm
+height_internal = 1;
 // snap gridz height to nearest 7mm increment
 enable_zsnap = false;
 


### PR DESCRIPTION
Motivated by [#147](https://github.com/kennetek/gridfinity-rebuilt-openscad/issues/147), I think it ends up more intuitive if upon opening the bin is actually a bin.

From a first impression perspective, it seems unlikely a user is opening up the bins.scad to produce a bin-sized-blank vs. a bin.