### PR TITLE
fix magnet hole position on 1/2 grid bins

### DIFF
--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -153,10 +153,10 @@ module block_base(gx, gy, l, dbnx, dbny, style_hole, off) {
         if (style_hole > 0)
             pattern_circular(abs(l-d_hole_from_side/2)<0.001?1:4)
             if (style_hole == 4)
-                translate([l/2-d_hole_from_side, l/2-d_hole_from_side, h_slit*2])
+                translate([l*dbnx/2-d_hole_from_side, l*dbny/2-d_hole_from_side, h_slit*2])
                 refined_hole();
             else
-                translate([l/2-d_hole_from_side, l/2-d_hole_from_side, 0])
+                translate([l*dbnx/2-d_hole_from_side, l*dbny/2-d_hole_from_side, 0])
                 block_base_hole(style_hole, off);
         }
 }


### PR DESCRIPTION
fixes #149, possibly also fixes #105.

magnet hole positions now respect the calculated or manually set grid division

![Bildschirmfoto vom 2024-01-23 12-44-47e](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/49094296/34bda357-3a43-4d72-9c51-ce21daac5abc)


only looks good on 1/2 grid bins. smaller divisions are too small for magnets.

![image](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/49094296/c3daa28a-3521-4e87-9f55-b82e6c317a9b)

