### PR TITLE
Add `style_lip` as argument to `gridfinityInit`

### DIFF
--- a/docs/bins.md
+++ b/docs/bins.md
@@ -43,6 +43,7 @@ gridy | { n>0 \| n∈R } | number of bases along the y-axis
 height | { n>0 \| n∈R } | height of the bin, in millimeters (but not exactly). <br> See the `height()` function for more info.
 height_internal | { n>0 \| n∈R } | height of the internal block. <br> Can be lower than bin height to save filament on custom bins. <br> default of 0 means use the calculated height.
 length | { n>0 \| n∈R } | length of one unit of the base. <br> default: 42 (The Answer to the Ultimate Question of Life, <br>the Universe, and Everything.)
+style_lip | {0, 1, 2} | if you are not stacking the bin, you can disable the top lip <br> to save space. <br>     • (0) Regular lip <br>     • (1) Subtract lip to save space <br>     • (2) Disable lip while retaining height
 
 ```
 // Example: generate a 3x3x6 bin with a 42mm unit size

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -56,11 +56,14 @@ module cutCylinders(n_divx=1, n_divy=1, cylinder_diameter=1, cylinder_height=1, 
 }
 
 // initialize gridfinity
-module gridfinityInit(gx, gy, h, h0 = 0, l = l_grid) {
+// sl:  lip style of this bin.
+//      0:Regular lip, 1:Remove lip subtractively, 2:Remove lip and retain height
+module gridfinityInit(gx, gy, h, h0 = 0, l = l_grid, sl = 0) {
     $gxx = gx;
     $gyy = gy;
     $dh = h;
     $dh0 = h0;
+    $style_lip = sl;
     color("tomato") {
     difference() {
         color("firebrick")
@@ -69,7 +72,7 @@ module gridfinityInit(gx, gy, h, h0 = 0, l = l_grid) {
     }
     color("royalblue")
     block_wall(gx, gy, l) {
-        if (style_lip == 0) profile_wall();
+        if ($style_lip == 0) profile_wall();
         else profile_wall2();
     }
     }
@@ -307,10 +310,10 @@ module block_cutter(x,y,w,h,t,s) {
     v_ang_tab = a_tab;
     v_ang_lip = 45;
 
-    ycutfirst = y == 0 && style_lip == 0;
-    ycutlast = abs(y+h-$gyy)<0.001 && style_lip == 0;
-    xcutfirst = x == 0 && style_lip == 0;
-    xcutlast = abs(x+w-$gxx)<0.001 && style_lip == 0;
+    ycutfirst = y == 0 && $style_lip == 0;
+    ycutlast = abs(y+h-$gyy)<0.001 && $style_lip == 0;
+    xcutfirst = x == 0 && $style_lip == 0;
+    xcutlast = abs(x+w-$gxx)<0.001 && $style_lip == 0;
     zsmall = ($dh+h_base)/7 < 3;
 
     ylen = h*($gyy*l_grid+d_magic)/$gyy-d_div;


### PR DESCRIPTION
When used as a library, `gridfinity-rebuilt-utility.scad` accepts all the bin properties to use as arguments to `gridfinityInit`, `cut`, or other methods, with the sole exception of `style_lip` which must be defined in the calling file.

This change adds `style_lip` as an argument to `gridfinityInit` to ensure `gridfinity-rebuilt-utility.scad` can be used as a library.