### PR TITLE
Pass `style_lip` argument in `gridfinityInit` usages

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -85,7 +85,7 @@ div_base_y = 0;
 // ===== IMPLEMENTATION ===== //
 
 color("tomato") {
-gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal) {
+gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, sl=style_lip) {
 
     if (divx > 0 && divy > 0) {
 

--- a/gridfinity-rebuilt-lite.scad
+++ b/gridfinity-rebuilt-lite.scad
@@ -66,7 +66,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
     union() {
         difference() {
             union() {
-                gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), 0, length)
+                gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), 0, length, sl=style_lip)
                 children();
                 gridfinityBase(gridx, gridy, length, div_base_x, div_base_y, style_hole, only_corners=only_corners);
             }
@@ -89,7 +89,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
                 }
 
                 translate([0,0,-4*h_base])
-                gridfinityInit(gridx, gridy, height(20,0), 0, length)
+                gridfinityInit(gridx, gridy, height(20,0), 0, length, sl=style_lip)
                 children();
             }
 
@@ -100,7 +100,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
                     difference() {
                         union() {
 
-                            gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), 0, length)
+                            gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), 0, length, sl=style_lip)
                             children();
                         }
 
@@ -120,7 +120,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
 
 
                             translate([0,0,-4*h_base])
-                            gridfinityInit(gridx, gridy, height(20,0), 0, length)
+                            gridfinityInit(gridx, gridy, height(20,0), 0, length, sl=style_lip)
                             children();
                         }
 


### PR DESCRIPTION
faff922757cda077bcfb934b76df6ded88b6ca30 migrated `style_lip` from a global value to be an argument to `gridfinityInit`, but the usages were not updated.

fixes #164