### PR TITLE
Added ability to customize tab sizes (d_tabw and d_tabh) + function for multiple equally sized bins

### DIFF
--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -91,13 +91,6 @@ module gridfinityInit(gx, gy, h, h0 = 0, l = l_grid, sl = 0) {
 //      Automatic alignment will use left tabs for bins on the left edge, right tabs for bins on the right edge, and center tabs everywhere else.
 // s:   toggle the rounded back corner that allows for easy removal
 
-/*
-module cut(x=0, y=0, w=1, h=1, t=1, s=1) {
-    translate([0,0,-$dh-h_base])
-    cut_move(x,y,w,h)
-    block_cutter(clp(x,0,$gxx), clp(y,0,$gyy), clp(w,0,$gxx-x), clp(h,0,$gyy-y), t, s);
-}
-*/
 module cut(x=0, y=0, w=1, h=1, t=1, s=1, tab_width=d_tabw, tab_height=d_tabh) {
     translate([0,0,-$dh-h_base])
     cut_move(x,y,w,h)
@@ -106,6 +99,16 @@ module cut(x=0, y=0, w=1, h=1, t=1, s=1, tab_width=d_tabw, tab_height=d_tabh) {
 
 
 // cuts equally sized bins over a given length at a specified position
+// bins_x:  number of bins along x-axis
+// bins_y:  number of bins along y-axis
+// len_x:   length (in gridfinity bases) along x-axis that the bins_x will fill
+// len_y:   length (in gridfinity bases) along y-axis that the bins_y will fill
+// pos_x:   start x position of the bins (left side)
+// pos_y:   start y position of the bins (bottom side)
+// style_tab:   Style of the tab used on the bins
+// scoop:   Weight of the scoop on the bottom of the bins
+// tab_width:   Width of the tab on the bins, in mm.
+// tab_height:  How far the tab will stick out over the bin, in mm. Default tabs fit 12mm labels, but for narrow bins can take up too much space over the opening. This setting allows 'slimmer' tabs for use with thinner labels, so smaller/narrower bins can be labeled and still keep a reasonable opening at the top. NOTE: The measurement is not 1:1 in mm, so a '3.5' value does not guarantee a tab that fits 3.5mm label tape. Use the 'measure' tool after rendering to check the distance between faces to guarantee it fits your needs.
 module cutEqualBins(bins_x=1, bins_y=1, len_x=1, len_y=1, pos_x=0, pos_y=0, style_tab=5, scoop=1, tab_width=d_tabw, tab_height=d_tabh) {
     // Calculate width and height of each bin based on total length and number of bins
     bin_width = len_x / bins_x;
@@ -125,9 +128,6 @@ module cutEqualBins(bins_x=1, bins_y=1, len_x=1, len_y=1, pos_x=0, pos_y=0, styl
         }
     }
 }
-
-
-
 
 // Translates an object from the origin point to the center of the requested compartment block, can be used to add custom cuts in the bin
 // See cut() module for parameter descriptions
@@ -339,7 +339,7 @@ module block_cutter(x,y,w,h,t,s,tab_width=d_tabw,tab_height=d_tabh) {
 
     v_len_tab = tab_height;
     v_len_lip = d_wall2-d_wall+1.2;
-    v_cut_tab = d_tabh - (2*r_f1)/tan(a_tab);
+    v_cut_tab = tab_height - (2*r_f1)/tan(a_tab);
     v_cut_lip = d_wall2-d_wall-d_clear;
     v_ang_tab = a_tab;
     v_ang_lip = 45;

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -113,7 +113,7 @@ module cutEqualBins(bins_x=1, bins_y=1, len_x=1, len_y=1, pos_x=0, pos_y=0, styl
     // Calculate width and height of each bin based on total length and number of bins
     bin_width = len_x / bins_x;
     bin_height = len_y / bins_y;
-    
+
     // Loop through each bin position in x and y direction
     for (i = [0:bins_x-1]) {
         for (j = [0:bins_y-1]) {
@@ -121,7 +121,7 @@ module cutEqualBins(bins_x=1, bins_y=1, len_x=1, len_y=1, pos_x=0, pos_y=0, styl
             // Adjust position by adding pos_x and pos_y to shift the entire grid of bins as needed
             bin_start_x = pos_x + i * bin_width;
             bin_start_y = pos_y + j * bin_height;
-            
+
             // Call the cut module to create each bin with calculated position and dimensions
             // Pass through the style_tab and scoop parameters
             cut(bin_start_x, bin_start_y, bin_width, bin_height, style_tab, scoop, tab_width=tab_width, tab_height=tab_height);


### PR DESCRIPTION
Added a function ('cutEqualBins') for cutting several identical bins, with their size divided along the specified length. Unlike the 'cutEqual' function, one can specify the position of the bins as well. See point '1' in attached image.

Added two parameters in 'cut' (and the modules it calls) for specifying tab width and tab height. Tab width helps with some bins, where a narrower tab can make it easier to grab f.x. long screws from a bins, as in '3' in the attached image. Tab height refers to how much the tab 'sticks out', so it fits either wider labels, or narrower labels without wasting space ('4' in image).

Attached image shows:
1. A line of equally sized bins
2. A 1.5 wide bin, with default label size, which can be difficult to reach into.
3. A 1.5 wide bin with a label size of 35, easier to reach into
4. A 1.5 wide bin, with a default-width, centered label that has a height of 5mm.

I've done my best to check the functions for bugs and it all seems to be working without any issues. With that said, I've only used Openscad for a few days now, and never opened a pull request, so if something is missing or I haven't followed protocol, please let me know and I'll do my best to fix it.

![numbered_illustration](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/16915363/c95446c8-a9e0-4ffe-965e-5426345517d8)
![code_for_numbered_illustration](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/16915363/1b20dc8b-8bdc-4f73-9619-a7a173fed927)
