### PR TITLE
Add chamfers to cylindrical cutout holes

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -54,6 +54,8 @@ cd = 10;
 ch = 1;
 // spacing to lid
 c_depth = 1;
+// chamfer around the top rim of the holes
+c_chamfer = 0.5;
 
 /* [Height] */
 // determine what the variable "gridz" applies to based on your use case

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -95,7 +95,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
 
     } else if (cdivx > 0 && cdivy > 0) {
 
-        cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation);
+        cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation, chamfer=c_chamfer);
     }
 }
 gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, style_hole, only_corners=only_corners);

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -31,7 +31,8 @@ module cutEqual(n_divx=1, n_divy=1, style_tab=1, scoop_weight=1) {
 // cylinder_height: height of cutouts
 // coutout_depth: offset from top to solid part of container
 // orientation: orientation of cylinder cutouts (0 = x direction, 1 = y direction, 2 = z direction)
-module cutCylinders(n_divx=1, n_divy=1, cylinder_diameter=1, cylinder_height=1, coutout_depth=0, orientation=0) {
+// chamfer: chamfer around the top rim of the holes
+module cutCylinders(n_divx=1, n_divy=1, cylinder_diameter=1, cylinder_height=1, coutout_depth=0, orientation=0, chamfer=0.5) {
     rotation = (orientation == 0)
             ? [0,90,0]
             : (orientation == 1)
@@ -48,9 +49,14 @@ module cutCylinders(n_divx=1, n_divy=1, cylinder_diameter=1, cylinder_height=1, 
         translate([0,0,-coutout_depth]) {
             rounded_rectangle(cutout_x, cutout_y, coutout_depth*2, r_base);
 
-        pattern_linear(x=n_divx, y=n_divy, sx=(gridx_mm - 2)/n_divx, sy=(gridy_mm - 2)/n_divy)
-            rotate(rotation)
-                    cylinder(r=cylinder_diameter/2, h=cylinder_height*2, center=true);
+            pattern_linear(x=n_divx, y=n_divy, sx=(gridx_mm - padding)/n_divx, sy=(gridy_mm - padding)/n_divy)
+                rotate(rotation)
+                    union() {
+                        cylinder(d=cylinder_diameter, h=cylinder_height*2, center=true);
+                        if (chamfer > 0) {
+                            translate([0,0,-chamfer]) cylinder(d1=cylinder_diameter, d2=cylinder_diameter+4*chamfer, h=2*chamfer);
+                        }
+                    };
         }
     }
 }


### PR DESCRIPTION
Here's how it looks in preview mode:

<img width="1061" alt="preview" src="https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/1934223/ed069b19-4be3-4552-9780-dc17289ebd63">

Here's how it looks in render mode:

<img width="1063" alt="render" src="https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/1934223/41d668f9-8064-4deb-b5a6-6cae638532de">