### PR TITLE
fix(utility): make internal auto height lower

### DIFF
--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -67,7 +67,7 @@ module gridfinityInit(gx, gy, h, h0 = 0, l = l_grid, sl = 0) {
     color("tomato") {
     difference() {
         color("firebrick")
-        block_bottom(h0==0?$dh-0.1:h0, gx, gy, l);
+        block_bottom(h0==0 ? $dh-1.3 : h0, gx, gy, l);
         children();
     }
     color("royalblue")


### PR DESCRIPTION
This PR lowers the automatic height of the internal block. I printed a bin with a divider down the middle, intending to stack other bins on top of it. However, I found that the divider is a little too tall and the bins on the top don't sit cleanly in the lip, they rest and pivot on the divider instead.

Another way to achieve this might be to introduce an automatic height offset variable instead of relying on a fixed value. That way you could still use the automatic setting but still adjust the max height. I'm open to other ideas too. 

I still need to make a test print to confirm the new value is correct, but the renders look right at least. 

Before:
<img width="867" alt="SCR-20240209-iykf" src="https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/404731/5084c48c-f54c-4ff3-b954-17eccf358233">

After:
<img width="881" alt="SCR-20240209-iyci" src="https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/404731/69812f27-34e1-4502-b84f-3d73194f9b6d">
