### PR TITLE
Pyramid example base fix

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -168,7 +168,7 @@ gridfinityBase(gx, gy, 42, 0, 0, 1);
 
 // Pyramid scheme bin
 /*
-gx = 4.5;
+gx = 4;
 gy = 4;
 gridfinityInit(gx, gy, height(6), 0, 42) {
     for (i = [0:gx-1])


### PR DESCRIPTION
The base for the Pyramid scheme bin example created an invalid base because it wasn't a whole number.

OpenSCAD version 2024.06.16.ai19601 (git d3a5acc88)


before
![image](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/8085744/6464ddff-9b10-49e4-8ef2-4c8492f3d606)


after

![image](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/8085744/b7ef0992-d837-4c64-a33b-2c1cea2a6435)

![image](https://github.com/kennetek/gridfinity-rebuilt-openscad/assets/8085744/8d9775ab-16e0-42da-9337-fbc073be83ca)
