### PR TITLE
feat: support crosshair base for single magnet

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -78,6 +78,8 @@ scoop = 1; //[0:0.1:1]
 div_base_x = 0;
 // number of divisions per 1 unit of base along the Y axis. (default 1, only use integers. 0 means automatically guess the right division)
 div_base_y = 0;
+// Base will have a single hole in the center (use with crosshair style base)
+single_hole = false;
 
 /* [Base Hole Options] */
 // only cut magnet/screw holes at the corners of the bin to save uneccesary print time
@@ -111,7 +113,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
         cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation, chamfer=c_chamfer);
     }
 }
-gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, hole_options, only_corners=only_corners);
+gridfinityBase(gridx, gridy, l_grid, div_base_x, div_base_y, hole_options, only_corners=only_corners, single_hole=single_hole);
 }
 
 

--- a/tests/test_baseplate.py
+++ b/tests/test_baseplate.py
@@ -111,6 +111,16 @@ class TestBasePlateHoles(unittest.TestCase):
         self.scad_runner.camera_arguments = self.scad_runner.camera_arguments.with_rotation(CameraRotations.AngledTop)
         self.scad_runner.create_image([], Path('magnet_and_counterbored_screw_holes_top.png'))
 
+    def test_crosshair_with_magnet(self):
+        vars = self.scad_runner.parameters
+        vars["enable_magnet"] = True
+        vars["chamfer_holes"] = False
+        vars["crush_ribs"] = False
+        vars["style_plate"] = 5
+        self.scad_runner.create_image([], Path('crosshair_with_magnet_bottom.png'))
+        self.scad_runner.camera_arguments = self.scad_runner.camera_arguments.with_rotation(CameraRotations.AngledTop)
+        self.scad_runner.create_image([], Path('crosshair_with_magnet_top.png'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds support for bases with a single hole/magnet as a single N45 S-06-02-N magnet should be strong enough in most (of my) cases.

The spoke width is a parameter, but the default value of 3 seems as sturdy as the skeletonized variant and uses pretty much the same amount of filament.

![image](https://github.com/user-attachments/assets/d496566c-b3e0-48a5-80e6-77d5ba3439bb)
![image](https://github.com/user-attachments/assets/2ff82ae3-556c-4949-aad9-4a07a29079f5)
