### PR TITLE
Add feature to suppress tabs from certain divisions

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -69,6 +69,8 @@ enable_zsnap = false;
 /* [Features] */
 // the type of tabs
 style_tab = 1; //[0:Full,1:Auto,2:Left,3:Center,4:Right,5:None]
+// which divisions have tabs
+place_tab = 0; // [0:Everywhere-Normal,1:Top-Left Division]
 // how should the top lip act
 style_lip = 0; //[0: Regular lip, 1:remove lip subtractively, 2: remove lip and retain height]
 // scoop weight percentage. 0 disables scoop, 1 is regular scoop. Any real number will scale the scoop.
@@ -105,7 +107,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
 
     if (divx > 0 && divy > 0) {
 
-        cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop);
+        cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop, place_tab = place_tab);
 
     } else if (cdivx > 0 && cdivy > 0) {
 

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -72,10 +72,19 @@ function height (z,d=0,l=0,enable_zsnap=true) =
 //          set n_div values to 0 for a solid bin
 // style_tab:   tab style for all compartments. see cut()
 // scoop_weight:    scoop toggle for all compartments. see cut()
-module cutEqual(n_divx=1, n_divy=1, style_tab=1, scoop_weight=1) {
+module cutEqual(n_divx=1, n_divy=1, style_tab=1, scoop_weight=1, place_tab=1) {
     for (i = [1:n_divx])
     for (j = [1:n_divy])
-    cut((i-1)*$gxx/n_divx,(j-1)*$gyy/n_divy, $gxx/n_divx, $gyy/n_divy, style_tab, scoop_weight);
+    {
+        if (
+            place_tab == 1 && (i != 1 || j != n_divy) // Top-Left Division
+        ) {
+            cut((i-1)*$gxx/n_divx,(j-1)*$gyy/n_divy, $gxx/n_divx, $gyy/n_divy, 5, scoop_weight);
+        }
+        else {
+            cut((i-1)*$gxx/n_divx,(j-1)*$gyy/n_divy, $gxx/n_divx, $gyy/n_divy, style_tab, scoop_weight);
+        }
+    }
 }
 
 

--- a/gridfinity-rebuilt-utility.scad
+++ b/gridfinity-rebuilt-utility.scad
@@ -72,6 +72,7 @@ function height (z,d=0,l=0,enable_zsnap=true) =
 //          set n_div values to 0 for a solid bin
 // style_tab:   tab style for all compartments. see cut()
 // scoop_weight:    scoop toggle for all compartments. see cut()
+// place_tab:   tab suppression for all compartments. see "gridfinity-rebuilt-bins.scad"
 module cutEqual(n_divx=1, n_divy=1, style_tab=1, scoop_weight=1, place_tab=1) {
     for (i = [1:n_divx])
     for (j = [1:n_divy])


### PR DESCRIPTION
In the use-case that prompted this feature, I needed divided bins, but the contents were only differentiated by color--not something that needs to be on a label as it's evident. In this case, the "extra" labels over the other divisions looked out-of-place, or like I hadn't added labels yet.

This feature allows the option to only place label tabs on some divisions. Currently, the options support the default behavior, and suppressing all but the upper-left tab, but the code *should* be relatively easy to extend. I can see a useful options for each corner, and maybe each side (just top row, just left row, etc), but I don't want to clutter the code unless they are needed.