### PR TITLE
Update Github CI and Pre-Commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 💾 Check out repository
-      uses: actions/checkout@v3
-
-    - name: 🪝 Cache pre-commit hooks
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pre-commit
-        key: "pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml')
-          }}"
-
+      uses: actions/checkout@v4
+    - uses: actions/setup-python@v3 # WARNING: This must be v3
     - name: ✨ Install pre-commit
-      shell: bash
-      run: python3 -m pip install pre-commit
-
+      uses: pre-commit/action@v3.0.1
     - name: 🔥 Test
       run: pre-commit run --show-diff-on-failure --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,24 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: check-merge-conflict
   - id: end-of-file-fixer
+  - id: fix-byte-order-marker
   - id: trailing-whitespace
+    args: [--markdown-linebreak-ext=md]
+  - id: check-case-conflict
+  - id: check-illegal-windows-names
+  - id: check-json
+  - id: check-yaml
+  #- id: name-tests-test  # Ensure's pytest files end in "_test.py
+  - id: no-commit-to-branch  # Prevent accidental commits to main
+
+- repo: local
+  hooks:
+  - id: no-stl
+    name: Forbid STL files
+    entry: Do not commit STL files.
+    language: fail
+    files: \.stl
+    types: [binary]


### PR DESCRIPTION
* Fixes CI not running.
* Allows markdown files to have hard linebreaks.
* Ads additional checks.