### PR TITLE
Base Updates. Fixes lite bins.

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -341,7 +341,7 @@ module square_baseplate_lip(height=0, size = l_grid) {
 
     corner_center_distance = size/2 - BASEPLATE_OUTSIDE_RADIUS;
 
-    render(convexity = 2) // Fixes ghosting in preview
+    //render(convexity = 2) // Fixes ghosting in preview
     union() {
         baseplate_lip(height, size, size);
         pattern_circular(4)

--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -321,7 +321,7 @@ module baseplate_lip(height=0, width=l_grid, length=l_grid) {
 
     additional_height = height + BASEPLATE_CLEARANCE_HEIGHT;
 
-    sweep_rounded(width-2*BASEPLATE_OUTSIDE_RADIUS, length-2*BASEPLATE_OUTSIDE_RADIUS)
+    sweep_rounded([width-2*BASEPLATE_OUTSIDE_RADIUS, length-2*BASEPLATE_OUTSIDE_RADIUS])
     translate([translation_x, additional_height, 0])
     polygon(concat(BASEPLATE_LIP, [
         [0, -additional_height],

--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -266,7 +266,7 @@ module hole_pattern(){
 }
 
 module cutter_countersink(){
-    screw_hole(SCREW_HOLE_RADIUS + d_clear, 2*h_base,
+    screw_hole(SCREW_HOLE_RADIUS + d_clear, 2*BASE_HEIGHT,
         false, BASEPLATE_SCREW_COUNTERSINK_ADDITIONAL_RADIUS);
 }
 
@@ -274,7 +274,7 @@ module cutter_counterbore(){
     screw_radius = SCREW_HOLE_RADIUS + d_clear;
     counterbore_height = BASEPLATE_SCREW_COUNTERBORE_HEIGHT + 2*LAYER_HEIGHT;
     union(){
-        cylinder(h=2*h_base, r=screw_radius);
+        cylinder(h=2*BASE_HEIGHT, r=screw_radius);
         difference() {
             cylinder(h = counterbore_height, r=BASEPLATE_SCREW_COUNTERBORE_RADIUS);
             make_hole_printable(screw_radius, BASEPLATE_SCREW_COUNTERBORE_RADIUS, counterbore_height);

--- a/gridfinity-rebuilt-lite.scad
+++ b/gridfinity-rebuilt-lite.scad
@@ -90,7 +90,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
                     intersection() {
                         difference() {
                             gridfinityBase([gridx, gridy], [length, length], hole_options=style_hole, -d_wall*2, false, only_corners=only_corners);
-                            translate([-gridx*length/2,-gridy*length/2,2*h_base])
+                            translate([-gridx*length/2,-gridy*length/2,2*BASE_HEIGHT])
                             cube([gridx*length,gridy*length,1000]);
                         }
                         translate([0,0,-1])
@@ -98,11 +98,11 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
                         translate([0,0,bottom_layer])
                         rounded_rectangle(gridx*1000, gridy*1000, 1000, r_f2);
                     }
-                    translate([0,0,h_base+d_clear])
-                    rounded_rectangle(gridx*length-0.5005-d_wall*2, gridy*length-0.5005-d_wall*2, h_base, r_f2);
+                    translate([0,0,BASE_HEIGHT+d_clear])
+                    rounded_rectangle(gridx*length-0.5005-d_wall*2, gridy*length-0.5005-d_wall*2, BASE_HEIGHT, r_f2);
                 }
 
-                translate([0,0,-4*h_base])
+                translate([0,0,-4*BASE_HEIGHT])
                 gridfinityInit(gridx, gridy, height(20,0), 0, length, sl=style_lip)
                 children();
             }
@@ -120,7 +120,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
                         intersection() {
                             difference() {
                                 gridfinityBase([gridx, gridy], [length, length], hole_options=style_hole, -d_wall*2, false, only_corners=only_corners);
-                                translate([-gridx*length/2,-gridy*length/2,2*h_base])
+                                translate([-gridx*length/2,-gridy*length/2,2*BASE_HEIGHT])
                                 cube([gridx*length,gridy*length,1000]);
                             }
                             translate([0,0,-1])
@@ -129,7 +129,7 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
                             rounded_rectangle(gridx*1000, gridy*1000, 1000, r_f2);
                         }
 
-                        translate([0,0,-4*h_base])
+                        translate([0,0,-4*BASE_HEIGHT])
                         gridfinityInit(gridx, gridy, height(20,0), 0, length, sl=style_lip)
                         children();
                     }

--- a/gridfinity-rebuilt-lite.scad
+++ b/gridfinity-rebuilt-lite.scad
@@ -69,6 +69,7 @@ hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, cru
 
 // Input all the cutter types in here
 color("tomato")
+render()
 gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, l_grid, hole_options, only_corners) {
     cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = 0);
 }
@@ -77,70 +78,24 @@ gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, l_gri
 
 module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, length, style_hole, only_corners) {
     height_mm = height(gridz, gridz_define, style_lip, enable_zsnap);
-    union() {
+
+    // Lower the bin start point by this amount.
+    // Made up for in bin height.
+    // Ensures divider walls smoothly transition to the bottom
+    lower_by_mm = BASE_HEIGHT + bottom_layer;
+
+    difference() {
+        translate([0, 0, -lower_by_mm])
+        gridfinityInit(gridx, gridy, height_mm+lower_by_mm, 0, length, sl=style_lip)
+        children();
+
+        // Underside of the base. Keep out zone.
+        render()
         difference() {
-            union() {
-                gridfinityInit(gridx, gridy, height_mm, 0, length, sl=style_lip)
-                children();
-                gridfinityBase([gridx, gridy], [length, length], hole_options=style_hole, only_corners=only_corners);
-            }
-
-            difference() {
-                union() {
-                    intersection() {
-                        difference() {
-                            gridfinityBase([gridx, gridy], [length, length], hole_options=style_hole, -d_wall*2, false, only_corners=only_corners);
-                            translate([-gridx*length/2,-gridy*length/2,2*BASE_HEIGHT])
-                            cube([gridx*length,gridy*length,1000]);
-                        }
-                        translate([0,0,-1])
-                        rounded_rectangle(gridx*length-0.5005-d_wall*2, gridy*length-0.5005-d_wall*2, 1000, r_f2);
-                        translate([0,0,bottom_layer])
-                        rounded_rectangle(gridx*1000, gridy*1000, 1000, r_f2);
-                    }
-                    translate([0,0,BASE_HEIGHT+d_clear])
-                    rounded_rectangle(gridx*length-0.5005-d_wall*2, gridy*length-0.5005-d_wall*2, BASE_HEIGHT, r_f2);
-                }
-
-                translate([0,0,-4*BASE_HEIGHT])
-                gridfinityInit(gridx, gridy, height(20,0), 0, length, sl=style_lip)
-                children();
-            }
+            cube([gridx*length, gridy*length, BASE_HEIGHT*2], center=true);
+            gridfinityBase([gridx, gridy], hole_options=style_hole, only_corners=only_corners);
         }
-        difference() {
-            translate([0,0,-1.6])
-            difference() {
-                difference() {
-                    union() {
-                        gridfinityInit(gridx, gridy, height_mm, 0, length, sl=style_lip)
-                        children();
-                    }
-
-                    difference() {
-                        intersection() {
-                            difference() {
-                                gridfinityBase([gridx, gridy], [length, length], hole_options=style_hole, -d_wall*2, false, only_corners=only_corners);
-                                translate([-gridx*length/2,-gridy*length/2,2*BASE_HEIGHT])
-                                cube([gridx*length,gridy*length,1000]);
-                            }
-                            translate([0,0,-1])
-                            rounded_rectangle(gridx*length-0.5005-d_wall*2, gridy*length-0.5005-d_wall*2, 1000, r_f2);
-                            translate([0,0,bottom_layer])
-                            rounded_rectangle(gridx*1000, gridy*1000, 1000, r_f2);
-                        }
-
-                        translate([0,0,-4*BASE_HEIGHT])
-                        gridfinityInit(gridx, gridy, height(20,0), 0, length, sl=style_lip)
-                        children();
-                    }
-
-                }
-                translate([0,0,9])
-                rounded_rectangle(gridx*1000, gridy*1000, gridz*1000, gridz);
-            }
-            translate([0,0,0])
-            rounded_rectangle(gridx*1000, gridy*1000, 5, r_f2);
-       }
-
     }
+
+    gridfinity_base_lite([gridx, gridy], d_wall, bottom_layer, hole_options=style_hole, only_corners=only_corners);
 }

--- a/gridfinity-spiral-vase.scad
+++ b/gridfinity-spiral-vase.scad
@@ -85,8 +85,8 @@ d_hole = 26;  // center-to-center distance between holes
 d_bottom = layer*(max(bottom_layer,1));
 x_l = l_grid/2;
 
-dht = (gridz_define==0)?gridz*7 : (gridz_define==1)?h_bot+gridz+h_base : gridz-(enable_lip?3.8:0);
-d_height = (enable_zsnap?((abs(dht)%7==0)?dht:dht+7-abs(dht)%7):dht)-h_base;
+dht = (gridz_define==0)?gridz*7 : (gridz_define==1)?h_bot+gridz+BASE_HEIGHT : gridz-(enable_lip?3.8:0);
+d_height = (enable_zsnap?((abs(dht)%7==0)?dht:dht+7-abs(dht)%7):dht)-BASE_HEIGHT;
 
 d_fo1 = 2*+BASE_TOP_RADIUS;
 
@@ -170,18 +170,18 @@ module gridfinityBaseVase() {
     difference() {
         intersection() {
             block_base_blank(0);
-            translate([0,0,-h_base-1])
-            rounded_square([l_grid-0.5-0.005, l_grid-0.5-0.005, h_base*10], BASE_TOP_RADIUS+0.001, center=true);
+            translate([0,0,-BASE_HEIGHT-1])
+            rounded_square([l_grid-0.5-0.005, l_grid-0.5-0.005, BASE_HEIGHT*10], BASE_TOP_RADIUS+0.001, center=true);
         }
         translate([0,0,0.01])
         difference() {
             block_base_blank(nozzle*4);
-            translate([0,0,-h_base])
+            translate([0,0,-BASE_HEIGHT])
             cube([l_grid*2,l_grid*2,d_bottom*2],center=true);
         }
         // magic slice
         rotate([0,0,90])
-        translate([0,0,-h_base+d_bottom+0.01])
+        translate([0,0,-BASE_HEIGHT+d_bottom+0.01])
         cube([0.001,l_grid*gridx,d_height+d_bottom*2]);
 
     }
@@ -189,7 +189,7 @@ module gridfinityBaseVase() {
     pattern_circular(4)
     intersection() {
         rotate([0,0,45])
-        translate([-nozzle,3,-h_base+d_bottom+0.01])
+        translate([-nozzle,3,-BASE_HEIGHT+d_bottom+0.01])
         cube([nozzle*2,l_grid*gridx,d_height+d_bottom*2]);
 
         block_base_blank(nozzle*4-0.1);
@@ -202,8 +202,8 @@ module gridfinityBaseVase() {
     pattern_circular(4)
     block_magnet_blank(0, false);
 
-    translate([0,0,h_base/2])
-    cube([l_grid*2, l_grid*2, h_base], center = true);
+    translate([0,0,BASE_HEIGHT/2])
+    cube([l_grid*2, l_grid*2, BASE_HEIGHT], center = true);
     }
 
     if (style_base != 4)
@@ -214,24 +214,24 @@ module gridfinityBaseVase() {
 module block_magnet_blank(o = 0, half = true) {
     magnet_radius = MAGNET_HOLE_RADIUS + o;
 
-    translate([d_hole/2,d_hole/2,-h_base+0.1])
+    translate([d_hole/2,d_hole/2,-BASE_HEIGHT+0.1])
     difference() {
         hull() {
             cylinder(r = magnet_radius, h = MAGNET_HOLE_DEPTH*2, center = true);
-            cylinder(r = magnet_radius-(h_base+0.1-MAGNET_HOLE_DEPTH), h = (h_base+0.1)*2, center = true);
+            cylinder(r = magnet_radius-(BASE_HEIGHT+0.1-MAGNET_HOLE_DEPTH), h = (BASE_HEIGHT+0.1)*2, center = true);
         }
         if (half)
         mirror([0,0,1])
-        cylinder(r=magnet_radius*2, h = (h_base+0.1)*4);
+        cylinder(r=magnet_radius*2, h = (BASE_HEIGHT+0.1)*4);
     }
 }
 
 module block_base_blank(o = 0) {
     mirror([0,0,1]) {
         hull() {
-            linear_extrude(h_base)
+            linear_extrude(BASE_HEIGHT)
             rounded_square(l_grid-o-0.05-2*r_c2-2*r_c1, r_fo3, center=true);
-            linear_extrude(h_base-r_c1)
+            linear_extrude(BASE_HEIGHT-r_c1)
             rounded_square(l_grid-o-0.05-2*r_c2, r_fo2, center=true);
         }
         hull() {
@@ -247,7 +247,7 @@ module block_base_blank(o = 0) {
 module block_pinch(height_mm) {
     assert(is_num(height_mm));
 
-    translate([0, 0, -h_base])
+    translate([0, 0, -BASE_HEIGHT])
     block_wall(gridx, gridy, l_grid) {
         translate([d_wall2-nozzle*2-d_clear*2,0,0])
         profile_wall(height_mm);
@@ -360,7 +360,7 @@ module block_funnel_outside() {
 module block_vase_base() {
     difference() {
         // base
-        translate([0,0,-h_base]) {
+        translate([0,0,-BASE_HEIGHT]) {
             translate([0,0,-0.1])
             color("firebrick")
             block_bottom(d_bottom, gridx, gridy, l_grid);

--- a/gridfinity-spiral-vase.scad
+++ b/gridfinity-spiral-vase.scad
@@ -88,7 +88,7 @@ x_l = l_grid/2;
 dht = (gridz_define==0)?gridz*7 : (gridz_define==1)?h_bot+gridz+h_base : gridz-(enable_lip?3.8:0);
 d_height = (enable_zsnap?((abs(dht)%7==0)?dht:dht+7-abs(dht)%7):dht)-h_base;
 
-d_fo1 = 2*+BASE_OUTSIDE_RADIUS;
+d_fo1 = 2*+BASE_TOP_RADIUS;
 
 f2c = sqrt(2)*(sqrt(2)-1); // fillet to chamfer ratio
 me = ((gridx*l_grid-0.5)/n_divx)-nozzle*4-d_fo1-12.7-4;
@@ -171,7 +171,7 @@ module gridfinityBaseVase() {
         intersection() {
             block_base_blank(0);
             translate([0,0,-h_base-1])
-            rounded_square([l_grid-0.5-0.005, l_grid-0.5-0.005, h_base*10], BASE_OUTSIDE_RADIUS+0.001, center=true);
+            rounded_square([l_grid-0.5-0.005, l_grid-0.5-0.005, h_base*10], BASE_TOP_RADIUS+0.001, center=true);
         }
         translate([0,0,0.01])
         difference() {
@@ -239,7 +239,7 @@ module block_base_blank(o = 0) {
             rounded_square(l_grid-o-0.05-2*r_c2, r_fo2, center=true);
             mirror([0,0,1])
             linear_extrude(d_bottom)
-            rounded_square(l_grid-o-0.05, BASE_OUTSIDE_RADIUS, center=true);
+            rounded_square(l_grid-o-0.05, BASE_TOP_RADIUS, center=true);
         }
     }
 }

--- a/src/core/gridfinity-rebuilt-holes.scad
+++ b/src/core/gridfinity-rebuilt-holes.scad
@@ -280,7 +280,7 @@ module block_base_hole(hole_options, o=0) {
     screw_radius = SCREW_HOLE_RADIUS - (o/2);
     magnet_radius = MAGNET_HOLE_RADIUS - (o/2);
     magnet_inner_radius = MAGNET_HOLE_CRUSH_RIB_INNER_RADIUS - (o/2);
-    screw_depth = h_base-o;
+    screw_depth = BASE_HEIGHT - o;
     // If using supportless / printable mode, need to add additional layers, so they can be removed later.
     supportless_additional_layers = screw_hole ? 2 : 3;
     magnet_depth = MAGNET_HOLE_DEPTH - o +

--- a/src/core/gridfinity-rebuilt-holes.scad
+++ b/src/core/gridfinity-rebuilt-holes.scad
@@ -263,7 +263,7 @@ module assert_hole_options_valid(hole_options) {
  * @brief A single magnet/screw hole.  To be cut out of the base.
  * @details Supports multiple options that can be mixed and matched.
  * @pram hole_options @see bundle_hole_options
- * @param o Offset
+ * @param o offset Grows or shrinks the final shapes.  Similar to `scale`, but in mm.
  */
 module block_base_hole(hole_options, o=0) {
     assert_hole_options_valid(hole_options);

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -307,6 +307,18 @@ module base_polygon() {
 }
 
 /**
+ * @brief Internal function to create the negative for a Gridfinity Refined thumbscrew hole.
+ * @details Magic constants are what the threads.ScrewHole function does.
+ */
+module _base_thumbscrew() {
+    ScrewThread(
+        1.01 * BASE_THUMBSCREW_OUTER_DIAMETER + 1.25 * 0.4,
+        BASE_HEIGHT,
+        BASE_THUMBSCREW_PITCH
+    );
+}
+
+/**
  * @brief A single Gridfinity base.  With holes (if set).
  * @param hole_options @see block_base_hole.hole_options
  * @param off
@@ -325,13 +337,6 @@ module block_base(hole_options, off=0, top_dimensions=BASE_TOP_DIMENSIONS, thumb
         str("Minimum size of a single base must be greater than ", 2*BASE_TOP_RADIUS)
     );
 
-    thumbscrew_outerdiam = 15;
-    thumbscrew_height = 5;
-    thumbscrew_tolerance = 0.4;
-    thumbscrew_tooth_angle = 30;
-    thumbscrew_pitch = 1.5;
-
-
     render(convexity = 2)
     difference() {
         union(){
@@ -343,14 +348,7 @@ module block_base(hole_options, off=0, top_dimensions=BASE_TOP_DIMENSIONS, thumb
         }
 
         if (thumbscrew) {
-            ScrewThread(
-                1.01 * thumbscrew_outerdiam + 1.25 * thumbscrew_tolerance,
-                thumbscrew_height,
-                thumbscrew_pitch,
-                thumbscrew_tooth_angle,
-                thumbscrew_tolerance,
-                tooth_height=0
-            );
+            _base_thumbscrew();
         }
         // 4 holes
         // Need this fancy code to support refined holes and non-square bases.

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -31,7 +31,7 @@ function fromGridfinityUnits(gridfinityUnit, includeLipHeight = false) =
  * @returns The final value in mm.
  */
 function includingFixedHeights(mmHeight, includeLipHeight = false) =
-    mmHeight + h_bot + h_base + (includeLipHeight ? STACKING_LIP_SIZE.y : 0);
+    mmHeight + h_bot + BASE_HEIGHT + (includeLipHeight ? STACKING_LIP_SIZE.y : 0);
 
 /**
  * @brief Three Functions in One. For height calculations.
@@ -63,7 +63,7 @@ function height (z,d=0,l=0,enable_zsnap=true) =
         hf(z,d,l)+7-abs(hf(z,d,l))%7
     )
     :hf(z,d,l)
-    ) -h_base;
+    ) - BASE_HEIGHT;
 
 // Creates equally divided cutters for the bin
 //
@@ -169,7 +169,7 @@ module gridfinityInit(gx, gy, h, h0 = 0, l = l_grid, sl = 0) {
 // s:   toggle the rounded back corner that allows for easy removal
 
 module cut(x=0, y=0, w=1, h=1, t=1, s=1, tab_width=d_tabw, tab_height=d_tabh) {
-    translate([0,0,-$dh-h_base])
+    translate([0, 0, -$dh - BASE_HEIGHT])
     cut_move(x,y,w,h)
     block_cutter(clp(x,0,$gxx), clp(y,0,$gyy), clp(w,0,$gxx-x), clp(h,0,$gyy-y), t, s, tab_width, tab_height);
 }
@@ -209,7 +209,7 @@ module cutEqualBins(bins_x=1, bins_y=1, len_x=1, len_y=1, pos_x=0, pos_y=0, styl
 // Translates an object from the origin point to the center of the requested compartment block, can be used to add custom cuts in the bin
 // See cut() module for parameter descriptions
 module cut_move(x, y, w, h) {
-    translate([0,0,$dh0==0?$dh+h_base:$dh0+h_base])
+    translate([0, 0, ($dh0==0 ? $dh : $dh0) + BASE_HEIGHT])
     cut_move_unsafe(clp(x,0,$gxx), clp(y,0,$gyy), clp(w,0,$gxx-x), clp(h,0,$gyy-y))
     children();
 }
@@ -260,7 +260,7 @@ module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_option
 
     // Top which ties all bases together
     if (final_cut) {
-        translate([0, 0, h_base-TOLLERANCE])
+        translate([0, 0, BASE_HEIGHT])
         rounded_square([grid_size_mm.x, grid_size_mm.y, h_bot], BASE_TOP_RADIUS, center=true);
     }
 
@@ -338,8 +338,8 @@ module block_base(hole_options, off=0, top_dimensions=BASE_TOP_DIMENSIONS, thumb
             sweep_rounded(sweep_inner)
                 base_polygon();
 
-            translate([0, 0, BASE_PROFILE_MAX.y/2])
-            cube([cube_size.x, cube_size.y, BASE_PROFILE_MAX.y], center=true);
+            translate([0, 0, BASE_HEIGHT/2])
+            cube([cube_size.x, cube_size.y, BASE_HEIGHT], center=true);
         }
 
         if (thumbscrew) {
@@ -450,13 +450,13 @@ module profile_wall2(height_mm) {
 }
 
 module block_wall(gx, gy, l) {
-    translate([0,0,h_base])
+    translate([0, 0, BASE_HEIGHT])
     sweep_rounded([gx*l-2*r_base-0.5-0.001, gy*l-2*r_base-0.5-0.001])
     children();
 }
 
 module block_bottom( h = 2.2, gx, gy, l ) {
-    translate([0,0,h_base+0.1])
+    translate([0, 0, BASE_HEIGHT + 0.1])
     rounded_rectangle(gx*l-0.5-d_wall/4, gy*l-0.5-d_wall/4, h, r_base+0.01);
 }
 
@@ -482,7 +482,7 @@ module block_cutter(x,y,w,h,t,s,tab_width=d_tabw,tab_height=d_tabh) {
     ycutlast = abs(y+h-$gyy)<0.001 && $style_lip == 0;
     xcutfirst = x == 0 && $style_lip == 0;
     xcutlast = abs(x+w-$gxx)<0.001 && $style_lip == 0;
-    zsmall = ($dh+h_base)/7 < 3;
+    zsmall = ($dh+BASE_HEIGHT)/7 < 3;
 
     ylen = h*($gyy*l_grid+d_magic)/$gyy-d_div;
     xlen = w*($gxx*l_grid+d_magic)/$gxx-d_div;
@@ -494,7 +494,7 @@ module block_cutter(x,y,w,h,t,s,tab_width=d_tabw,tab_height=d_tabh) {
     cut = (zsmall || t == 5) ? (ycutlast?v_cut_lip:0) : v_cut_tab;
     style = (t > 1 && t < 5) ? t-3 : (x == 0 ? -1 : xcutlast ? 1 : 0);
 
-    translate([0,ylen/2,h_base+h_bot])
+    translate([0, ylen/2, BASE_HEIGHT+h_bot])
     rotate([90,0,-90]) {
 
     if (!zsmall && xlen - tab_width > 4*r_f2 && (t != 0 && t != 5)) {

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -266,10 +266,19 @@ module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_option
 
     if(only_corners) {
         difference(){
-            pattern_linear(final_grid_size.x, final_grid_size.y, base_center_distance_mm.x, base_center_distance_mm.y)
-            block_base(bundle_hole_options(), 0, individual_base_size_mm, thumbscrew=thumbscrew);
+            pattern_linear(final_grid_size.x, final_grid_size.y, base_center_distance_mm.x, base_center_distance_mm.y) {
+                base_solid(individual_base_size_mm);
+            }
+
+            if(thumbscrew) {
+                thumbscrew_position = grid_size_mm - individual_base_size_mm;
+                pattern_linear(2, 2, thumbscrew_position.x, thumbscrew_position.y) {
+                    _base_thumbscrew();
+                }
+            }
 
             _base_holes(hole_options, off, grid_size_mm);
+            _base_preview_fix();
         }
     }
     else {
@@ -365,7 +374,6 @@ module block_base(hole_options, offset=0, top_dimensions=BASE_TOP_DIMENSIONS, th
 
     base_bottom = base_bottom_dimensions(top_dimensions);
 
-    render(convexity = 2)
     difference() {
         base_solid(top_dimensions);
 
@@ -373,6 +381,19 @@ module block_base(hole_options, offset=0, top_dimensions=BASE_TOP_DIMENSIONS, th
             _base_thumbscrew();
         }
         _base_holes(hole_options, offset, top_dimensions);
+        _base_preview_fix();
+    }
+}
+
+/**
+ * @brief Internal code.  Fix base preview rendering issues.
+ * @details Preview does not like perfect top/bottoms.
+ */
+module _base_preview_fix() {
+    if($preview){
+        cube([10000, 10000, 0.01], center=true);
+        translate([0, 0, BASE_HEIGHT])
+        cube([10000, 10000, 0.01], center=true);
     }
 }
 

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -386,6 +386,31 @@ module block_base(hole_options, offset=0, top_dimensions=BASE_TOP_DIMENSIONS, th
 }
 
 /**
+ * @brief Outer shell of a Gridfinity base.
+ * @param wall_thickness How thick the walls are.
+ * @param bottom_thickness How thick the bottom is.
+ * @param top_dimensions [x, y] size of a single base.  Only set if deviating from the standard!
+ */
+module base_outer_shell(wall_thickness, bottom_thickness, top_dimensions=BASE_TOP_DIMENSIONS) {
+    assert(is_num(wall_thickness) && wall_thickness > 0);
+    assert((is_num(bottom_thickness) && bottom_thickness > 0));
+
+    union(){
+        difference(){
+            base_solid(top_dimensions=top_dimensions);
+            base_solid(top_dimensions=foreach_add(top_dimensions, -2*wall_thickness));
+            _base_preview_fix();
+        }
+        //Bottom
+        intersection() {
+            translate([0, 0, bottom_thickness/2])
+            cube([top_dimensions.x, top_dimensions.y, bottom_thickness], center=true);
+            base_solid(top_dimensions=top_dimensions);
+        }
+    }
+}
+
+/**
  * @brief Internal code.  Fix base preview rendering issues.
  * @details Preview does not like perfect top/bottoms.
  */

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -324,7 +324,7 @@ module block_base(hole_options, off=0, size=[BASE_SIZE, BASE_SIZE], thumbscrew=f
     render(convexity = 2)
     difference() {
         union() {
-            sweep_rounded(base_profile_size.x, base_profile_size.y)
+            sweep_rounded(base_profile_size)
             translate([translation_x, 0, 0])
             polygon(BASE_PROFILE);
 
@@ -448,7 +448,7 @@ module profile_wall2(height_mm) {
 
 module block_wall(gx, gy, l) {
     translate([0,0,h_base])
-    sweep_rounded(gx*l-2*r_base-0.5-0.001, gy*l-2*r_base-0.5-0.001)
+    sweep_rounded([gx*l-2*r_base-0.5-0.001, gy*l-2*r_base-0.5-0.001])
     children();
 }
 

--- a/src/core/standard.scad
+++ b/src/core/standard.scad
@@ -174,6 +174,11 @@ BASE_TOP_DIMENSIONS = [41.5, 41.5];
 BASE_PROFILE_MAX = BASE_PROFILE[3];
 
 /**
+ * @Summary Height of the base.
+ */
+BASE_HEIGHT = BASE_PROFILE_MAX.y;
+
+/**
  * @Summary Corner radius of the bottom of the base.
  * @Details This is also how much BASE_PROFILE needs to be translated
  *          to use `sweep_rounded(...)`.
@@ -190,12 +195,6 @@ function base_bottom_dimensions(top_dimensions = BASE_TOP_DIMENSIONS) =
         && is_num(top_dimensions.x) && is_num(top_dimensions.y))
     [top_dimensions.x - 2*BASE_PROFILE_MAX.x,
     top_dimensions.y - 2*BASE_PROFILE_MAX.x];
-
-/**
- * @summary Height of the raw base
- * @Deprecated
- */
-h_base = BASE_PROFILE_MAX.y;
 
 // ****************************************
 // Baseplate constants

--- a/src/core/standard.scad
+++ b/src/core/standard.scad
@@ -196,6 +196,14 @@ function base_bottom_dimensions(top_dimensions = BASE_TOP_DIMENSIONS) =
     [top_dimensions.x - 2*BASE_PROFILE_MAX.x,
     top_dimensions.y - 2*BASE_PROFILE_MAX.x];
 
+// ***************
+// Gridfinity Refined Thumbscrew
+// See https://www.printables.com/model/413761-gridfinity-refined
+// ***************
+
+BASE_THUMBSCREW_OUTER_DIAMETER=15;
+BASE_THUMBSCREW_PITCH=1.5;
+
 // ****************************************
 // Baseplate constants
 // Based on https://gridfinity.xyz/specification/

--- a/src/helpers/generic-helpers.scad
+++ b/src/helpers/generic-helpers.scad
@@ -175,11 +175,21 @@ function affine_scale(vector) = [
 
 /**
  * @brief Create a rectangle with rounded corners by sweeping a 2d object along a path.
- *        Centered on origin.
+ * @Details Centered on origin.
+ *          Result is on the X,Y plane.
+ *          Expects children to be a 2D shape in Quardrant 1 of the X,Y plane.
+ * @param size Dimensions of the resulting object.
+ *             Either a single number or [width, length]
  */
-module sweep_rounded(width=10, length=10) {
-    assert(width > 0 && length > 0);
+module sweep_rounded(size) {
+    assert((is_num(size) && size > 0) || (
+        is_list(size) && len(size) == 2 &&
+        is_num(size.x) && size.x > 0 && is_num(size.y) && size.y > 0
+        )
+    );
 
+    width = is_num(size) ? size : size.x;
+    length = is_num(size) ? size : size.y;
     half_width = width/2;
     half_length = length/2;
     path_points = [

--- a/src/helpers/generic-helpers.scad
+++ b/src/helpers/generic-helpers.scad
@@ -174,6 +174,17 @@ function affine_scale(vector) = [
 ];
 
 /**
+ * @brief Add something to each element in a list.
+ * @param list The list whos elements will be modified.
+ * @param to_add
+ * @returns a list with `to_add` added to each element in the list.
+ */
+function foreach_add(list, to_add) =
+    assert(is_list(list))
+    assert(!is_undef(to_add))
+    [for (item = list) item + to_add];
+
+/**
  * @brief Create a rectangle with rounded corners by sweeping a 2d object along a path.
  * @Details Centered on origin.
  *          Result is on the X,Y plane.


### PR DESCRIPTION
Re-worked the base creation code. Again...

Lite bins now look like this (3x3 base, 2x2 compartments):
![image](https://github.com/user-attachments/assets/463b052b-7dc2-4976-9580-6176f54c6dc1)

* Fixes #242
* Fixes #232
* Fixes #224
* May Fix #212
* Fixes # #194

The lite bases don't have quite as many options as the regular bins.  However for the simple case this should be a nice solution.  It also massively simplifies the code.

I am thinking of moving base generation code to a separate file, but this is good enough for the moment.