### PR TITLE
feat: support partially extending bases & adjustable half-grid hole positions

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -68,13 +68,6 @@ c_depth = 1;
 // chamfer around the top rim of the holes
 c_chamfer = 0.5; // .1
 
-/* [Split Compartments] */
-// divide into 2 compartments by this ratio
-ratiox = 0; // [0:0.001:1]
-// divide into 2 compartments by this ratio
-ratioy = 0; // [0:0.001:1]
-
-
 /* [Height] */
 // determine what the variable "gridz" applies to based on your use case
 gridz_define = 0; // [0:gridz is the height of bins in units of 7mm increments - Zack's method,1:gridz is the internal height in millimeters, 2:gridz is the overall external height of the bin in millimeters]
@@ -120,11 +113,7 @@ hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, cru
 color("tomato") {
 gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, sl=style_lip, extra=[extrax,extray]) {
 
-    if ((ratiox > 0 && ratiox < 1) || (ratioy > 0 && ratioy < 1)) {
-
-        cutByRatio(rx = ratiox, ry = ratioy, style_tab = style_tab, scoop_weight = scoop, place_tab = place_tab);
-
-    } else if (divx > 0 && divy > 0) {
+    if (divx > 0 && divy > 0) {
 
         cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop, place_tab = place_tab);
 

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -40,10 +40,10 @@ gridx = 3; //.5
 gridy = 2; //.5
 // bin height. See bin height information and "gridz_define" below.
 gridz = 6; //.1
-/* [General Advanced Settings] */
-// extend width (in mm, negative is to left, pos to right)
+/* [Advanced Settings] */
+// extend total grid width (in mm, negative is to left, pos to right)
 extrax=0; // [-41.99:0.01:41.99]
-// extend length (in mm, negative is to front, pos to back)
+// extend total grid length (in mm, negative is to front, pos to back)
 extray=0; // [-41.99:0.01:41.99]
 
 /* [Linear Compartments] */

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -40,6 +40,11 @@ gridx = 3; //.5
 gridy = 2; //.5
 // bin height. See bin height information and "gridz_define" below.
 gridz = 6; //.1
+/* [General Advanced Settings] */
+// extend width (in mm, negative is to left, pos to right)
+extrax=0; // [-41.99:0.01:41.99]
+// extend length (in mm, negative is to left, pos to right)
+extray=0; // [-41.99:0.01:41.99]
 
 /* [Linear Compartments] */
 // number of X Divisions (set to zero to have solid bin)
@@ -62,6 +67,13 @@ ch = 1;  //.1
 c_depth = 1;
 // chamfer around the top rim of the holes
 c_chamfer = 0.5; // .1
+
+/* [Split Compartments] */
+// divide into 2 compartments by this ratio
+ratiox = 0; // [0:0.001:1]
+// divide into 2 compartments by this ratio
+ratioy = 0; // [0:0.001:1]
+
 
 /* [Height] */
 // determine what the variable "gridz" applies to based on your use case
@@ -98,24 +110,31 @@ chamfer_holes = true;
 printable_hole_top = true;
 // Enable "gridfinity-refined" thumbscrew hole in the center of each base: https://www.printables.com/model/413761-gridfinity-refined
 enable_thumbscrew = false;
+// Align holes to the left of the base for half grid bases
+half_grid_hole_alignment = 0; // [0: Upper left corner, 1: Base pattern but left aligned, 2: Normal base pattern]
 
 hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, crush_ribs, chamfer_holes, printable_hole_top);
 
 // ===== IMPLEMENTATION ===== //
 
 color("tomato") {
-gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, sl=style_lip) {
+gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, sl=style_lip, extra=[extrax,extray]) {
 
-    if (divx > 0 && divy > 0) {
+    if ((ratiox > 0 && ratiox < 1) || (ratioy > 0 && ratioy < 1)) {
+
+        cutByRatio(rx = ratiox, ry = ratioy, style_tab = style_tab, scoop_weight = scoop, place_tab = place_tab);
+
+    } else if (divx > 0 && divy > 0) {
 
         cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = scoop, place_tab = place_tab);
 
     } else if (cdivx > 0 && cdivy > 0) {
 
         cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation, chamfer=c_chamfer);
+
     }
 }
-gridfinityBase([gridx, gridy], hole_options=hole_options, only_corners=only_corners, thumbscrew=enable_thumbscrew);
+gridfinityBase([gridx, gridy], hole_options=hole_options, only_corners=only_corners, thumbscrew=enable_thumbscrew, half_grid_hole_alignment=half_grid_hole_alignment, extra=[extrax, extray]);
 }
 
 

--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -43,7 +43,7 @@ gridz = 6; //.1
 /* [General Advanced Settings] */
 // extend width (in mm, negative is to left, pos to right)
 extrax=0; // [-41.99:0.01:41.99]
-// extend length (in mm, negative is to left, pos to right)
+// extend length (in mm, negative is to front, pos to back)
 extray=0; // [-41.99:0.01:41.99]
 
 /* [Linear Compartments] */

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -148,43 +148,6 @@ module cutCylinders(n_divx=1, n_divy=1, cylinder_diameter=1, cylinder_height=1, 
     }
 }
 
-// Create two or four cutters for the bin divided by the given ratio (max 4 cutouts per bin)
-//
-// rx:  ratio to divide x-axis by
-// ry:  ratio to divide y-axis by
-// style_tab:   tab style for all compartments. see cut()
-// scoop_weight:    scoop toggle for all compartments. see cut()
-// place_tab:   tab suppression for all compartments. see "gridfinity-rebuilt-bins.scad"
-module cutByRatio(rx=1, ry=1, style_tab=1, scoop_weight=1, place_tab=1) {
-    n_divx=rx > 0 && rx < 1 ? 2 : 1;
-    n_divy=ry > 0 && ry < 1 ? 2 : 1;
-
-    // opposite cut ratio
-    orx=1 - rx;
-    ory=1 - ry;
-
-    for (i = [1:n_divx])
-    for (j = [1:n_divy]) {
-        // disable style_tab if only Top-Left Division checked
-        tab_style=place_tab == 1 && (i != 1 || j != n_divy) ? 5 : style_tab;
-
-        cut(
-          (i - 1)*rx*$gxx,
-          (j - 1)*ry*$gyy,
-          (i == 1 ? rx : orx)*$gxx,
-          (j == 1 ? ry : ory)*$gyy,
-          tab_style,
-          scoop_weight,
-          offsets=[
-            ($extrax < 0 ? (i == 1 ? 1 : orx) : (i-1)*rx)*$extrax,
-            ($extray < 0 ? (j == 1 ? 1 : ory) : (j-1)*ry)*$extray,
-            (i == 1 ? rx : orx)*abs($extrax),
-            (j == 1 ? ry : ory)*abs($extray)
-          ]
-        );
-    }
-}
-
 // initialize gridfinity
 // sl:  lip style of this bin.
 //      0:Regular lip, 1:Remove lip subtractively, 2:Remove lip and retain height

--- a/src/core/standard.scad
+++ b/src/core/standard.scad
@@ -38,7 +38,7 @@ d_hole_from_side=8;
 // Based on https://gridfinity.xyz/specification/
 HOLE_DISTANCE_FROM_BOTTOM_EDGE = 4.8;
 
-// Meassured diameter in Fusion360.
+// Measured diameter in Fusion360.
 // Smaller than the magnet to keep it squeezed.
 REFINED_HOLE_RADIUS = 5.86 / 2;
 REFINED_HOLE_HEIGHT = MAGNET_HEIGHT - 0.1;

--- a/src/helpers/generic-helpers.scad
+++ b/src/helpers/generic-helpers.scad
@@ -74,9 +74,12 @@ module pattern_linear(x = 1, y = 1, sx = 0, sy = 0) {
     yy = sy <= 0 ? sx : sy;
     translate([-(x-1)*sx/2,-(y-1)*yy/2,0])
     for (i = [1:ceil(x)])
-    for (j = [1:ceil(y)])
-    translate([(i-1)*sx,(j-1)*yy,0])
-    children();
+    for (j = [1:ceil(y)]) {
+      $is_odd_x = (i%2) == 1;
+      $is_odd_y = (j%2) == 1;
+      translate([(i-1)*sx,(j-1)*yy,0])
+      children();
+    }
 }
 
 module pattern_circular(n=2) {


### PR DESCRIPTION
Although this might go against the basic principle of gridfinity, I had a drawer that did not have an inner size that was a nice multiple of 42. But I still want to make use of the extra 2cm, so I added support to extend the grid with partial bases as I'd rather have some bins that I can only use on one side of the drawers then leave a gap of 2cm.

This PR also adds support to configure how the magnet holes should be positioned when using half grids.

Extend bases with 2cm to the left and 7mm to the back. Note that there aren't bottom notches added on the extra 7mm yaxis because the bottom notches have a minimum dimension of `2*BASE_TOP_RADIUS`. See the warning that is being echoed
![image](https://github.com/user-attachments/assets/e54f45ad-bbf2-4290-94eb-b826c52bdae8)

Compartments are still equally divided taking the extra dimensions into account:
![image](https://github.com/user-attachments/assets/c513e53a-4dd5-4c09-b433-7d2bb11122b7)

Default / current behaviour for placement of half grid holes:
![image](https://github.com/user-attachments/assets/0392261b-ae27-4634-a393-b3213a73440a)

Alternate y alignment like the full width base pattern but keep all holes left aligned:
![image](https://github.com/user-attachments/assets/bbb49d7f-fe72-4114-884d-576058e9fe32)

Use the default hole pattern for full width bases:
![image](https://github.com/user-attachments/assets/c719dd8f-c3b5-47fd-a2c2-a542c13dce3a)
