### PR TITLE
Fix overhang issue and flat grid-joinment.

### DIFF
--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -318,7 +318,7 @@ module gridfinity_base_lite(grid_size, wall_thickness, top_bottom_thickness, hol
         rounded_square([grid_size_mm.x, grid_size_mm.y, max(top_bottom_thickness/4, 0.5)], BASE_TOP_RADIUS, center=true);
 
         pattern_linear(grid_size.x, grid_size.y, grid_dimensions.x, grid_dimensions.y)
-        translate([0, 0, top_bottom_thickness/3])
+        translate([0, 0, max(top_bottom_thickness/3, 0.5)])
         base_solid();
     }
 

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -314,11 +314,11 @@ module gridfinity_base_lite(grid_size, wall_thickness, top_bottom_thickness, hol
 
     //Bridging structure to tie the bases together
     difference() {
-        translate([0, 0, BASE_HEIGHT-top_bottom_thickness])
-        rounded_square([grid_size_mm.x, grid_size_mm.y, top_bottom_thickness], BASE_TOP_RADIUS, center=true);
+        translate([0, 0, BASE_HEIGHT])
+        rounded_square([grid_size_mm.x, grid_size_mm.y, max(top_bottom_thickness/4, 0.5)], BASE_TOP_RADIUS, center=true);
 
         pattern_linear(grid_size.x, grid_size.y, grid_dimensions.x, grid_dimensions.y)
-        translate([0, 0, top_bottom_thickness])
+        translate([0, 0, top_bottom_thickness/3])
         base_solid();
     }
 


### PR DESCRIPTION
Fix the Baseplate Issue described in [#249](https://github.com/kennetek/gridfinity-rebuilt-openscad/issues/249)

Rework of implementation in Commit 3e4d870

The fix also makes it such that the bin itself sits WAY better in the base. (it extends the bottom of the bin a slight bit (0.5mm) which is no problem.)

Fixes this overhang issue:

**Before**:
First closing layer:
![image](https://github.com/user-attachments/assets/06f8a2a7-78ff-4b2d-9970-58fc21cf5b98)
Top seem layer:
![image](https://github.com/user-attachments/assets/74ebb19d-8ae4-4289-8f94-bd461c7759ea)
From below:
![image](https://github.com/user-attachments/assets/d163f8f4-db48-4c7c-bd27-0e7074fd5612)
Printed (here you can also see the flat intersection of the grid elements):
![printed](https://github.com/user-attachments/assets/b6825cfc-a67f-46fd-b7c5-ce6400eb58ff)


**After**:
First closing layer:
![image](https://github.com/user-attachments/assets/f1478fc9-e12e-4346-99a4-b867de7625d9)
Top connection layer
![image](https://github.com/user-attachments/assets/09c16e06-0725-4d71-a7e6-073a49602aa3)
From below:
![image](https://github.com/user-attachments/assets/c60a2ddf-9c01-4cb2-b59c-8197517422e2)
Printed (no cleanup, deeper intersection for better base fitment):
![WhatsApp Image 2025-03-23 at 01 41 04_05444f4d](https://github.com/user-attachments/assets/6e7db3d0-f4ea-4039-b84d-50522384ea0c)


