### PR TITLE
Bin base Grid sub-division force implemented

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -101,6 +101,10 @@ enable_thumbscrew = false;
 
 hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, crush_ribs, chamfer_holes, printable_hole_top);
 
+/* [Base Minimum Divisions] */
+div_base_x = 1;
+div_base_y = 1;
+
 // ===== IMPLEMENTATION ===== //
 
 color("tomato") {
@@ -115,7 +119,7 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
         cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation, chamfer=c_chamfer);
     }
 }
-gridfinityBase([gridx, gridy], hole_options=hole_options, only_corners=only_corners, thumbscrew=enable_thumbscrew);
+gridfinityBase([gridx, gridy], hole_options=hole_options, only_corners=only_corners, thumbscrew=enable_thumbscrew,min_base_div=[div_base_x,div_base_y]);
 }
 
 

--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -245,8 +245,9 @@ module cut_move(x, y, w, h) {
  * @param grid_size Number of bases in each dimension. [x, y]
  * @param grid_dimensions [length, width] of a single Gridfinity base.
  * @param thumbscrew Enable "gridfinity-refined" thumbscrew hole in the center of each base unit. This is a ISO Metric Profile, 15.0mm size, M15x1.5 designation.
+ * @param min_base_div as a scalar or list of values to determine the minimum divisor for the base grid, 1/2/4 will automatically be determined and applied but this can override.  For example a 3.5x2 bin will automatically use x-axis base divisor of 2 but only y-axis base divisor of 1.  by supplying 2, or [2,2], both will be forced to divisor of 2.
  */
-module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_options=bundle_hole_options(), off=0, final_cut=true, only_corners=false, thumbscrew=false) {
+module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_options=bundle_hole_options(), off=0, final_cut=true, only_corners=false, thumbscrew=false,min_base_div=[1,1]) {    
     assert(is_list(grid_dimensions) && len(grid_dimensions) == 2 &&
         grid_dimensions.x > 0 && grid_dimensions.y > 0);
     assert(is_list(grid_size) && len(grid_size) == 2 &&
@@ -267,7 +268,7 @@ module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_option
     dbnxt = [for (i=[1,2,4]) if (abs(grid_size.x*i)%1 < 0.001 || abs(grid_size.x*i)%1 > 0.999) i];
     dbnyt = [for (i=[1,2,4]) if (abs(grid_size.y*i)%1 < 0.001 || abs(grid_size.y*i)%1 > 0.999) i];
     assert(len(dbnxt) > 0 && len(dbnyt) > 0, "Base only supports half and quarter grid spacing.");
-    divisions_per_grid = [dbnxt[0], dbnyt[0]];
+    divisions_per_grid = [max(dbnxt[0],valueOfListElementOrLast(min_base_div,0)), max(dbnyt[0],valueOfListElementOrLast(min_base_div,1))];
 
     // Final size in number of bases
     final_grid_size = [grid_size.x * divisions_per_grid.x, grid_size.y * divisions_per_grid.y];

--- a/src/helpers/generic-helpers.scad
+++ b/src/helpers/generic-helpers.scad
@@ -184,6 +184,14 @@ function foreach_add(list, to_add) =
     assert(!is_undef(to_add))
     [for (item = list) item + to_add];
 
+    
+// list/Vector helper function:
+// this will return the scalar value from a list (l) indicated (by index), use the last value in the list if the index would go past the end of the list, or return the scalar value of (l) if it is not a list
+// this function allows elegantly using parameters passed as scalar values, or as lists of scalar values
+// for example, a scale that applies equally to all axies, or a list with separate scales for each axis
+function valueOfListElementOrLast(l,index) = (index>=0)?(is_list(l)?((index<len(l))?l[index]:l[len(l)-1]):l):0; 
+    
+    
 /**
  * @brief Create a rectangle with rounded corners by sweeping a 2d object along a path.
  * @Details Centered on origin.


### PR DESCRIPTION
This re-surfaces a simple and direct way to sub-divide the base grid even when not required to fit the bin size.

This adds, in the customizer, "Base Minimum Divisions" section to the gridfinity-rebuilt-bins.scad file.  Then the code is implemented to force the base subdivision to the specified values, even if not auto-calculated to be needed.  For example a 3x2 bin will not normally divide the base like 3.5x2.5 would (which would divide x and y by 2).  If you pass 2 or [2,2] as the min_base_div, then the base will be divided by 2 for both x and y for 3x2 bin too.

There is little overhead or added complexity to the code and the automatic sub-division code still works.

Are other conversations regarding this feature which existed in gridfinity-rebuilt-bins.scad until October 13, 2024 when the auto-calculation feature replaced it.


--------- specifics of where I changed or implemented code ---------


in gridfinity-rebuilt-bins.scad is surfaced in the customizer div_base_x and div_base_y in a new "Base Minimum Divisions" section.  I also added the necessary code in the call to gridfinityBase to pass these parameters.

In gridfinity-rebuilt-utility.scad I added a parameter to gridfinityBase to specify x and or y base divisions
The code to implement this is quite simple and minimal and allows dividing the base (for example to 21mm x 21mm) regardless of whether the bin dimensions require that sub-division.

I've added a function in generic-helpers.scad
function valueOfListElementOrLast(l,index)
which makes it easier to handle a parameter which may be a simple scalar value or a list of values

