### PR TITLE
Simplify how half grid bins are created.

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -24,6 +24,7 @@ https://github.com/kennetek/gridfinity-rebuilt-openscad
 
 */
 
+include <src/core/standard.scad>
 use <src/core/gridfinity-rebuilt-utility.scad>
 use <src/core/gridfinity-rebuilt-holes.scad>
 
@@ -35,11 +36,13 @@ $fs = 0.25; // .01
 
 /* [General Settings] */
 // number of bases along x-axis
-gridx = 3; //.5
+gridx = 3;
 // number of bases along y-axis
-gridy = 2; //.5
+gridy = 2;
 // bin height. See bin height information and "gridz_define" below.
 gridz = 6; //.1
+// Half grid sized bins.  Implies "only corners".
+half_grid = false;
 
 /* [Linear Compartments] */
 // number of X Divisions (set to zero to have solid bin)
@@ -100,11 +103,12 @@ printable_hole_top = true;
 enable_thumbscrew = false;
 
 hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, crush_ribs, chamfer_holes, printable_hole_top);
+grid_dimensions = GRID_DIMENSIONS_MM / (half_grid ? 2 : 1);
 
 // ===== IMPLEMENTATION ===== //
 
-color("tomato") {
-gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, sl=style_lip) {
+//color("tomato") {
+gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, grid_dimensions=grid_dimensions, sl=style_lip) {
 
     if (divx > 0 && divy > 0) {
 
@@ -115,8 +119,8 @@ gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap
         cutCylinders(n_divx=cdivx, n_divy=cdivy, cylinder_diameter=cd, cylinder_height=ch, coutout_depth=c_depth, orientation=c_orientation, chamfer=c_chamfer);
     }
 }
-gridfinityBase([gridx, gridy], hole_options=hole_options, only_corners=only_corners, thumbscrew=enable_thumbscrew);
-}
+gridfinityBase([gridx, gridy], grid_dimensions=grid_dimensions, hole_options=hole_options, only_corners=only_corners || half_grid, thumbscrew=enable_thumbscrew);
+//}
 
 
 // ===== EXAMPLES ===== //

--- a/gridfinity-rebuilt-lite.scad
+++ b/gridfinity-rebuilt-lite.scad
@@ -19,11 +19,13 @@ $fs = 0.25;
 
 /* [General Settings] */
 // number of bases along x-axis
-gridx = 3; //.5
+gridx = 3;
 // number of bases along y-axis
-gridy = 3; //.5
+gridy = 3;
 // bin height. See bin height information and "gridz_define" below.
 gridz = 6;
+// Half grid sized bins.  Implies "only corners".
+half_grid = false;
 
 /* [Compartments] */
 // number of X Divisions
@@ -64,19 +66,20 @@ chamfer_holes = true;
 printable_hole_top = true;
 
 hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, crush_ribs, chamfer_holes, printable_hole_top);
+grid_dimensions = GRID_DIMENSIONS_MM / (half_grid ? 2 : 1);
 
 // ===== IMPLEMENTATION ===== //
 
 // Input all the cutter types in here
 color("tomato")
 render()
-gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, l_grid, hole_options, only_corners) {
+gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, grid_dimensions, hole_options, only_corners || half_grid) {
     cutEqual(n_divx = divx, n_divy = divy, style_tab = style_tab, scoop_weight = 0);
 }
 
 // ===== CONSTRUCTION ===== //
 
-module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, length, style_hole, only_corners) {
+module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap, grid_dimensions, style_hole, only_corners) {
     height_mm = height(gridz, gridz_define, style_lip, enable_zsnap);
 
     // Lower the bin start point by this amount.
@@ -86,16 +89,16 @@ module gridfinityLite(gridx, gridy, gridz, gridz_define, style_lip, enable_zsnap
 
     difference() {
         translate([0, 0, -lower_by_mm])
-        gridfinityInit(gridx, gridy, height_mm+lower_by_mm, 0, length, sl=style_lip)
+        gridfinityInit(gridx, gridy, height_mm+lower_by_mm, 0, grid_dimensions, sl=style_lip)
         children();
 
         // Underside of the base. Keep out zone.
         render()
         difference() {
-            cube([gridx*length, gridy*length, BASE_HEIGHT*2], center=true);
-            gridfinityBase([gridx, gridy], hole_options=style_hole, only_corners=only_corners);
+            cube([gridx*grid_dimensions.x, gridy*grid_dimensions.y, BASE_HEIGHT*2], center=true);
+            gridfinityBase([gridx, gridy], grid_dimensions, hole_options=style_hole, only_corners=only_corners);
         }
     }
 
-    gridfinity_base_lite([gridx, gridy], d_wall, bottom_layer, hole_options=style_hole, only_corners=only_corners);
+    gridfinity_base_lite([gridx, gridy], grid_dimensions, d_wall, bottom_layer, hole_options=style_hole, only_corners=only_corners);
 }


### PR DESCRIPTION
* Instead of trying to automatically calculate it in gridfinityBase, add a toggle and pass grid_dimensions everywhere.
* Ads support for half grid bins to gridfinitiy-rebuilt-lite.
* Fixes issue with gridfinity-rebuilt-lite passing a scalar instead of grid_dimensions.

* Fixes #281
* Fixes #276
* Supersedes #284