### PR TITLE
Double-Scoop

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -81,8 +81,10 @@ style_tab = 1; //[0:Full,1:Auto,2:Left,3:Center,4:Right,5:None]
 place_tab = 0; // [0:Everywhere-Normal,1:Top-Left Division]
 // how should the top lip act
 style_lip = 0; //[0: Regular lip, 1:remove lip subtractively, 2: remove lip and retain height]
-// scoop weight percentage. 0 disables scoop, 1 is regular scoop. Any real number will scale the scoop.
-scoop = 1; //[0:0.1:1]
+// front scoop weight percentage. 0 disables scoop, 1 is regular scoop. Any real number will scale the scoop. (>1 are extreme scoops but may have use)
+scoopF = 0; //[0:0.1:3]
+// back (tab side of bin) scoop weight percentage. 0 disables scoop, 1 is regular scoop. Any real number will scale the scoop.
+scoopB = 0; //[0:0.1:3]
 
 /* [Base Hole Options] */
 // only cut magnet/screw holes at the corners of the bin to save uneccesary print time
@@ -106,6 +108,7 @@ hole_options = bundle_hole_options(refined_holes, magnet_holes, screw_holes, cru
 grid_dimensions = GRID_DIMENSIONS_MM / (half_grid ? 2 : 1);
 
 // ===== IMPLEMENTATION ===== //
+scoop = [scoopF,scoopB];
 
 //color("tomato") {
 gridfinityInit(gridx, gridy, height(gridz, gridz_define, style_lip, enable_zsnap), height_internal, grid_dimensions=grid_dimensions, sl=style_lip) {


### PR DESCRIPTION
Allows scoop to be defined as vector to specify 'back' scoop separately, otherwise it is exactly like usual.  Scoop can still be a scalar for 'front' scoop only.

Addressing issues #264 & #251

Light modifications to gridfinity-rebuilt-bins.scad to allow configuring scoopB as well as scoopF (which was previously just 'scoop'.  'scoop' then becomes a vector passed to cutEqual and on down through the various included calls.

in gridfinity-rebuilt-utility.scad:
  updated the comments documenting "module cut" to match the pre-existing code
slightly modified code to properly handle the existing 't', 's', 'tab_width' & 'tab_height' parameters to use default if undef is passed. (this can help if using the customizer to optionally provide values)

Also, "module cut" now allows double-scoop definition (set scoop to a vector with two values if you want to specify both front and back scoop weights) 'front' and 'back' scoop can be independently set.

Using a scalar scoop, or vector with one value, provides the previous behavior of setting the front scoop only.

"module profile_cutter" is also modified, accommodating scoop weight being a scalar (like previously) or a vector with one or two values for front and possibly back scoop weights.

It now also constrains the profile_cutter's volume, even if scoop weights exceed the normal range.

The attached animation shows a bin cross-section with 1) normal scoop in increments, 2) back scoop in increments, 3) both scoops together in increments, 4) normal scoop to extreme values, 5) both scoops together to extreme values, and a repeat of the same steps with a bin with tab.


![ScoopAnimation](https://github.com/user-attachments/assets/5ec8d7e4-1894-4aed-9c8d-76aec2554674)

