### PR TITLE
Add stacking lip notches

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -80,7 +80,7 @@ style_tab = 1; //[0:Full,1:Auto,2:Left,3:Center,4:Right,5:None]
 // which divisions have tabs
 place_tab = 0; // [0:Everywhere-Normal,1:Top-Left Division]
 // how should the top lip act
-style_lip = 0; //[0: Regular lip, 1:remove lip subtractively, 2: remove lip and retain height]
+style_lip = 0; //[0: Regular lip, 1:remove lip subtractively, 2: remove lip and retain height, 3: regular Lip with Notches]
 // scoop weight percentage. 0 disables scoop, 1 is regular scoop. Any real number will scale the scoop.
 scoop = 1; //[0:0.1:1]
 


### PR DESCRIPTION
Add new stacking lip style ($style_lip == 3) for standard stacking lip with notch positions for alignment
The geometry of the notch is added in module lipNotch in gridfinity-rebuilt-utility.scad

the notches are added inside gridfinityInit immediately after the outer wall is constructed and swept.

The notch placements are aligned to match standard and half-grid bins, whichever is configured.

block_cutter is slightly modified to understand the new $style_lip value of 3

The gridfinity-rebuilt-bins.scad file has this value (3) added to the comment used by the customizer for style_lip

This addresses feature request #219

![Screenshot 2025-04-28 at 1 45 59 PM](https://github.com/user-attachments/assets/208cc8c2-ac11-4081-8868-934abc40697e)

![Screenshot 2025-04-28 at 1 46 47 PM](https://github.com/user-attachments/assets/cd4997ee-2609-45da-99e4-90b8c6937ec3)
