### PR TITLE
Thin bin wall profile fixed

### DIFF
--- a/src/core/gridfinity-rebuilt-utility.scad
+++ b/src/core/gridfinity-rebuilt-utility.scad
@@ -561,15 +561,20 @@ module stacking_lip_filleted() {
  * @brief External wall profile, with a stacking lip.
  * @details Translated so a 90 degree rotation produces the expected outside radius.
  */
+ // now uses intersection to assure proper profile even down to gridz=1
 module profile_wall(height_mm) {
     assert(is_num(height_mm))
-    translate([r_base - STACKING_LIP_SIZE.x, 0, 0]){
-        translate([0, height_mm, 0])
-        stacking_lip_filleted();
-        translate([STACKING_LIP_SIZE.x-d_wall, 0, 0])
-        square([d_wall, height_mm]);
+    intersection() {
+        translate([r_base - STACKING_LIP_SIZE.x, 0, 0]){
+            translate([0, height_mm, 0])
+            stacking_lip_filleted();
+            translate([STACKING_LIP_SIZE.x-d_wall, 0, 0])
+            square([d_wall, height_mm]);
+        }
+        square([10,10+height_mm]);
     }
 }
+
 
 // lipless profile
 module profile_wall2(height_mm) {


### PR DESCRIPTION
Thin bin wall profile fixed to avoid invalid geometry with gridz as low as 1.0.  simple intersection added to limit the profile as gridz (height_mm) gets very low.

This addresses issue #286 , that discussion contains images of the current broken behavior as gridz goes below around 1.5.  
There are also images with this bug fix in-place.

This fix keeps things clean and well structured for gridz all the way down to 1.0.

