### PR TITLE
Add option for magnets on bottom of baseplate

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -59,6 +59,8 @@ style_hole = 0; // [0:none, 1:countersink, 2:counterbore]
 /* [Magnet Hole] */
 // Baseplate will have holes for 6mm Diameter x 2mm high magnets.
 enable_magnet = true;
+// Baseplate will have holes for 6x2 magnets on bottom to stick to steel surface.
+enable_bottom_magnet = true;
 // Magnet holes will have crush ribs to hold the magnet.
 crush_ribs = true;
 // Magnet holes will have a chamfer to ease insertion.
@@ -191,6 +193,28 @@ module gridfinityBaseplate(grid_size_bases, length, min_size_mm, sp, hole_option
                             } else if (sh == 2) {
                                 cutter_counterbore();
                             }
+                        }
+                    }
+                }
+                // bottom magnet holes
+                if (enable_bottom_magnet) {
+
+                    bm_hole_options = bundle_hole_options(refined_hole=false, magnet_hole=true, screw_hole=false, crush_ribs=crush_ribs, chamfer=chamfer_holes, supportless=true);
+
+                    early_padding = [for (i = [0:1]) padding_mm[i] * (1 - fit_percent_positive[i])];
+                    late_padding = [for (i = [0:1]) padding_mm[i] * fit_percent_positive[i]];
+
+                    bm_start_early = [for (i = [0:1]) (early_padding[i] >= BOTTOM_MAGNET_MIN_PAD) ? 1 : 0];
+                    bm_end_late = [for (i = [0:1]) (late_padding[i] >= BOTTOM_MAGNET_MIN_PAD) ? 1 : 0];
+                    bm_start_index = [for (i = [0:1]) bm_start_early[i] ? 0 : 1];
+                    bm_end_index = [for (i = [0:1]) grid_size[i] + bm_end_late[i]];
+                    bm_translate = [for (i = [0:1]) (bm_end_late[i] - bm_start_early[i]) * length/2];
+
+                    translate(bm_translate) {
+                        pattern_linear(bm_end_index.x - bm_start_index.x, bm_end_index.y - bm_start_index.y, length) {
+                            translate([0, 0, -TOLLERANCE])
+                                block_base_hole(bm_hole_options);
+                            cylinder(d=2.5, h=20);
                         }
                     }
                 }

--- a/src/core/standard.scad
+++ b/src/core/standard.scad
@@ -33,6 +33,9 @@ SCREW_HOLE_RADIUS = 3 / 2;
 MAGNET_HOLE_RADIUS = 6.5 / 2;
 MAGNET_HOLE_DEPTH = MAGNET_HEIGHT + (LAYER_HEIGHT * 2);
 
+// minimum padding width that allows a bottom magnet at the edge of the baseplate
+BOTTOM_MAGNET_MIN_PAD = MAGNET_HOLE_RADIUS + 1;
+
 // distance of hole from side of bin
 d_hole_from_side=8;
 


### PR DESCRIPTION
Hi.  Here comes a new feature out of the blue.

A great way to use a thin style baseplate and use the magnets in Gridfinity bins is to line the drawer with a thin steel sheet, then have magnets in both the bins and the baseplate to stick to the sheet.  There is just enough room in the corners of a thin baseplate for a 6x2 magnet.

You can see bottom magnets in use in this Mastodon thread.
https://chaos.social/@kbob/113634630860874471

So this patch adds a bottom magnet option.

Some design choices I made (changeable, of course).

* There's a configuration boolean in the Magnet Hole section, "enable bottom magnet".
* Bottom magnets use the same settings for crush ribs and chamfers as top magnets.
* Bottom magnet holes are always made printable.
* Bottom magnets always have a 2.5mm hole up to the top of the baseplate for pushing the magnet out.
* If there's room, bottom magnets are added in the padding area as well as between squares.  Enough room is defined as one millimeter of padding  past the magnet edge.  (hardcoded)

Bottom magnets are most useful with thin baseplates.  Chamfers don't work with thin plates; the walls are too thin at the corners.   So it might be better to always disable bottom magnet chamfers or disable them for thin plates.  