### PR TITLE
Fix broken parameters in baseplate options

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -101,7 +101,7 @@ module gridfinityBaseplate(grid_size_bases, length, min_size_mm, sp, hole_option
     assert(grid_size_bases.y > 0 || min_size_mm.y > 0,
         "Must have positive y grid amount!");
 
-    additional_height = calculate_offset(sp, hole_options[1], sh);
+    additional_height = calculate_offset(sp, hole_options[2], sh);
 
     // Final height of the baseplate. In mm.
     baseplate_height_mm = additional_height + BASEPLATE_HEIGHT;
@@ -228,7 +228,7 @@ function calculate_offset(style_plate, enable_magnet, style_hole) =
 function calculate_offset_skeletonized(enable_magnet, style_hole) =
     h_skel + (enable_magnet ? MAGNET_HOLE_DEPTH : 0) +
     (
-        style_hole==0 ? d_screw :
+        style_hole==0 ? 0 :
         style_hole==1 ? BASEPLATE_SCREW_COUNTERSINK_ADDITIONAL_RADIUS : // Only works because countersink is at 45 degree angle!
         BASEPLATE_SCREW_COUNTERBORE_HEIGHT
     );


### PR DESCRIPTION
Fixes two issues I found in the baseplate file:

1. Use the correct magnet hole option when calling `calculate_offset`. Looks like the options struct was reconfigured to have its name as the first element, but this usage wasn't updated to increment the index up by one.
2. The offset logic for the skeletonized baseplate incorrectly adds about 3mm of unneeded plastic to the bottom when no screw holes are specified. Not sure if this is intentional, but I don't see why it would be needed.