### PR TITLE
Add option for magnet holes in edge only

### DIFF
--- a/gridfinity-rebuilt-bins.scad
+++ b/gridfinity-rebuilt-bins.scad
@@ -87,6 +87,8 @@ scoop = 1; //[0:0.1:1]
 /* [Base Hole Options] */
 // only cut magnet/screw holes at the corners of the bin to save uneccesary print time
 only_corners = false;
+// only cut magnet/screw holes at the edges of the bin to save uneccesary print time
+only_edges = false;
 //Use gridfinity refined hole style. Not compatible with magnet_holes!
 refined_holes = true;
 // Base will have holes for 6mm Diameter x 2mm high magnets.
@@ -114,7 +116,8 @@ bin1 = new_bin(
     hole_options = hole_options,
     only_corners = only_corners || half_grid,
     thumbscrew = enable_thumbscrew,
-    grid_dimensions = GRID_DIMENSIONS_MM / (half_grid ? 2 : 1)
+    grid_dimensions = GRID_DIMENSIONS_MM / (half_grid ? 2 : 1),
+    only_edges = only_edges,
 );
 
 echo(str(

--- a/src/core/base.scad
+++ b/src/core/base.scad
@@ -21,14 +21,16 @@ _debug = false;
  * @param grid_dimensions [length, width] of a single Gridfinity base.
  * @param thumbscrew Enable "gridfinity-refined" thumbscrew hole in the center of each base unit. This is a ISO Metric Profile, 15.0mm size, M15x1.5 designation.
  */
-module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_options=bundle_hole_options(), only_corners=false, thumbscrew=false) {
+module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_options=bundle_hole_options(), only_corners=false, thumbscrew=false, only_edges=false) {
     assert(is_list(grid_dimensions) && len(grid_dimensions) == 2 &&
         grid_dimensions.x > 0 && grid_dimensions.y > 0);
     assert(is_list(grid_size) && len(grid_size) == 2 &&
         grid_size.x > 0 && grid_size.y > 0);
     assert(
         is_bool(only_corners) &&
-        is_bool(thumbscrew)
+        is_bool(thumbscrew) &&
+        is_bool(only_edges)
+        
     );
 
     individual_base_size_mm = grid_dimensions - BASE_GAP_MM;
@@ -59,6 +61,17 @@ module gridfinityBase(grid_size, grid_dimensions=GRID_DIMENSIONS_MM, hole_option
             _base_holes(hole_options, grid_size_mm);
             _base_preview_fix();
         }
+    }
+    else if (only_edges)
+    {
+        pattern_grid(grid_size, grid_dimensions, true, true)
+        block_base(hole_options, individual_base_size_mm, thumbscrew=thumbscrew);
+        intersection () {
+            pattern_grid(grid_size, grid_dimensions, true, true)
+            block_base(bundle_hole_options(), individual_base_size_mm, thumbscrew=thumbscrew);
+            cube(size = [ (grid_size.x-1)*grid_dimensions.x, (grid_size.y-1)*grid_dimensions.y, 14 ], center = true);
+        }
+
     }
     else {
         pattern_grid(grid_size, grid_dimensions, true, true)

--- a/src/core/bin.scad
+++ b/src/core/bin.scad
@@ -49,7 +49,8 @@ function new_bin(
         only_corners=false,
         thumbscrew=false,
         grid_dimensions = GRID_DIMENSIONS_MM,
-        base_thickness = BASE_HEIGHT
+        base_thickness = BASE_HEIGHT,
+        only_edges=false,
     ) =
     assert(is_valid_2d(grid_size) && is_positive(grid_size))
     assert(is_num(height_mm) && height_mm >= BASE_HEIGHT)
@@ -69,6 +70,7 @@ function new_bin(
         || fill_height <= 0
         || fill_height <= height_mm - STACKING_LIP_SUPPORT_HEIGHT,
         str("Maximum fill_height for this bin is", height_mm - STACKING_LIP_SUPPORT_HEIGHT))
+    assert(is_bool(only_edges))
     let(fill_height_calculated = include_lip ?
         height_mm - BASE_HEIGHT - STACKING_LIP_SUPPORT_HEIGHT
         : height_mm - BASE_HEIGHT)
@@ -94,7 +96,8 @@ function new_bin(
         undef,
         hole_options,
         only_corners,
-        thumbscrew
+        thumbscrew,
+        only_edges
     ];
 
 /*
@@ -151,6 +154,7 @@ module bin_render_infill(bin) {
     hole_options = bin[8];
     only_corners = bin[9];
     thumbscrew = bin[10];
+    only_edges = bin[11];
 
     grid_size_mm = as_2d(grid_get_total_dimensions(base_grid));
     grid_size = bin_get_bases(bin);
@@ -177,7 +181,8 @@ module bin_render_infill(bin) {
                 grid_dimensions=grid_dimensions,
                 hole_options=hole_options,
                 only_corners=only_corners,
-                thumbscrew=thumbscrew);
+                thumbscrew=thumbscrew,
+                only_edges=only_edges);
         }
     }
 }
@@ -211,6 +216,7 @@ module bin_render_base(bin) {
     hole_options = bin[8];
     only_corners = bin[9];
     thumbscrew = bin[10];
+    only_edges = bin[11];
 
     grid_size = bin_get_bases(bin);
     grid_dimensions = bin_get_grid_dimensions(bin);
@@ -220,14 +226,16 @@ module bin_render_base(bin) {
             grid_dimensions=grid_dimensions,
             hole_options=hole_options,
             only_corners=only_corners,
-            thumbscrew=thumbscrew);
+            thumbscrew=thumbscrew,
+            only_edges=only_edges);
     } else {
         gridfinity_base_lite(grid_size,
             grid_dimensions=grid_dimensions,
             wall_thickness=d_wall,
             bottom_thickness=base_thickness,
             hole_options=hole_options,
-            only_corners=only_corners);
+            only_corners=only_corners,
+            only_edges=only_edges);
     }
 }
 


### PR DESCRIPTION
Fixes #218 
I took the code from #220 and merged it into the latest branch

First time touching openscad so let me know if there are any improvements to be made.

I do see a possibility of having an enum for magnets (None,All,Corners,Edges).

Samples:
## 4x3
<img width="599" height="541" alt="image" src="https://github.com/user-attachments/assets/fb699872-7a80-4bdf-abc1-d80df6bb0b88" />

## 3x2
<img width="513" height="384" alt="image" src="https://github.com/user-attachments/assets/6478f3cf-ad8f-4ac5-8a26-d866259b6852" />

## 3x1
<img width="513" height="328" alt="image" src="https://github.com/user-attachments/assets/ca6286f4-4015-4645-a2ac-8b759506ce6e" />


