### PR TITLE
Make label tab width, depth, and height configurable

### DIFF
--- a/src/core/cutouts.scad
+++ b/src/core/cutouts.scad
@@ -59,13 +59,21 @@ use <../helpers/grid_element.scad>
  *        134: +y wall, left edge.
  * @param center_top Default true, cutter [x, y] is centered on the current position.
  *        If false, cutter is in quadrant 1 [+x, +y].
+ * @param tab_depth How deep the tab protrudes into the bin, in mm.
+ *        Defaults to the library-standard depth.
+ * @param tab_height Total vertical extent of the tab, in mm.
+ *        Defaults to the height that keeps the support ramp at the
+ *        library-standard overhang angle.
+ *        Shrinking height while keeping depth fixed flattens the overhang
+ *        (the underside ramp angle = atan((height - support_height) / depth)).
  */
-module compartment_cutter(size_mm, scoop_percent=0, tab_width=0, tab_angle=90, center_top=true) {
+module compartment_cutter(size_mm, scoop_percent=0, tab_width=0, tab_angle=90, center_top=true, tab_depth=_tab_depth, tab_height=undef) {
     assert(is_valid_3d(size_mm) && is_positive(size_mm));
     assert(is_num(scoop_percent));
     assert(is_num(tab_angle)
         || (is_undef(tab_angle) && tab_width == 0));
     assert(is_bool(center_top));
+    assert(is_num(tab_depth) && tab_depth > 0);
 
     translate_by = center_top ? [0, 0, 0]
         : [size_mm.x/2, size_mm.y/2, 0];
@@ -85,7 +93,9 @@ module compartment_cutter(size_mm, scoop_percent=0, tab_width=0, tab_angle=90, c
             _compartment_tab(
                 size_mm+as_3d(TOLLERANCE),
                 tab_width+TOLLERANCE,
-                tab_angle);
+                tab_angle,
+                tab_depth,
+                tab_height);
         }
     }
 }
@@ -118,18 +128,22 @@ module _half_rounded_square(size_mm) {
  * @param tab_angle Determines where the tab is placed.
  *                  This will be normalized.
  *                  Regardless of compartment dimensions, corners are always at 45 degree intervals.
+ * @param tab_depth How deep the tab protrudes into the bin.
+ * @param tab_height Total vertical extent of the tab.
  */
-module _compartment_tab(size_mm, tab_width, tab_angle) {
+module _compartment_tab(size_mm, tab_width, tab_angle, tab_depth=_tab_depth, tab_height=undef) {
     assert(is_valid_2d(size_mm) && is_positive(size_mm));
     assert(is_num(tab_angle));
     assert(is_num(tab_width) && tab_width > 0);
+    assert(is_num(tab_depth) && tab_depth > 0);
 
     size_2d = as_2d(size_mm);
     normalized_angle = normalize_to_box(size_2d, tab_angle);
+    resolved_height = is_undef(tab_height) ? default_tab_height(tab_depth) : tab_height;
 
     snap_to_edge(size_2d, normalized_angle, tab_width)
-    translate([0, 0, -TAB_SIZE.y])
-    tab(tab_width);
+    translate([0, 0, -resolved_height])
+    tab(tab_width, tab_depth, resolved_height);
 }
 
 /**
@@ -175,8 +189,16 @@ module _compartment_scoop(size_mm, scoop_percent) {
  * @param tab_top_left_only If the tab will only be on the top left compartment.
  *        Only false is supported when `grid_element_current` is not available.
  * @param scoop 0.0-1.0 How much of a scoop should be present.
+ * @param tab_width Override the tab width (along the wall).
+ *        Defaults to `TAB_WIDTH_NOMINAL` for all styles except Full, which spans the compartment.
+ *        Ignored when style_tab is None (5).
+ * @param tab_depth How deep the tab protrudes into the bin, in mm.
+ *        Defaults to the library-standard depth.
+ * @param tab_height Total vertical extent of the tab, in mm.
+ *        Defaults to the height that keeps the support ramp at the
+ *        library-standard overhang angle.
  */
-module cut_compartment_auto(size_mm, style_tab=5, tab_top_left_only=false, scoop_percent=0) {
+module cut_compartment_auto(size_mm, style_tab=5, tab_top_left_only=false, scoop_percent=0, tab_width=undef, tab_depth=_tab_depth, tab_height=undef) {
 
     // Lambda so `grid_element_current()` is only called when needed.
     // It can throw!
@@ -186,11 +208,14 @@ module cut_compartment_auto(size_mm, style_tab=5, tab_top_left_only=false, scoop
         && grid_element_is_first_col(element);
 
     has_tab = style_tab != 5 && (!tab_top_left_only || is_top_left());
-    tab_width = !has_tab ? 0
-        : style_tab == 0 ? max(size_mm) : TAB_WIDTH_NOMINAL;
+    default_tab_width = style_tab == 0 ? max(size_mm) : TAB_WIDTH_NOMINAL;
+    resolved_tab_width = !has_tab ? 0
+        : is_undef(tab_width) ? default_tab_width
+        : tab_width;
     tab_angle = has_tab ? get_tab_angle(style_tab) : 0;
 
-    compartment_cutter(size_mm, scoop_percent, tab_width, tab_angle);
+    compartment_cutter(size_mm, scoop_percent, resolved_tab_width, tab_angle,
+                       tab_depth=tab_depth, tab_height=tab_height);
 }
 
 /**

--- a/src/core/standard.scad
+++ b/src/core/standard.scad
@@ -99,6 +99,45 @@ TAB_POLYGON = [
  */
 TAB_SIZE = TAB_POLYGON[2];
 
+/**
+ * @brief Tab height yielding a given support-ramp angle at a given depth.
+ * @details Lets callers think in print-overhang terms rather than absolute
+ *          millimeters. Pair with `tab_height` on `cut_compartment_auto` /
+ *          `compartment_cutter` when picking the angle is more natural
+ *          than picking the height.
+ * @param depth How deep the tab protrudes into the bin.
+ * @param angle Support-ramp angle from horizontal, in degrees.
+ */
+function tab_height_from_angle(depth, angle) =
+    tan(angle) * depth + _tab_support_height;
+
+/**
+ * @brief Default tab height for a given inward protrusion depth.
+ * @details Thin wrapper around `tab_height_from_angle` using the library's
+ *          canonical overhang angle.
+ * @param depth How deep the tab protrudes into the bin.
+ */
+function default_tab_height(depth=_tab_depth) =
+    tab_height_from_angle(depth, _tab_support_angle);
+
+/**
+ * @brief Tab cross-section polygon.
+ * @details Matches `TAB_POLYGON` when both defaults are used.
+ *          The support-ramp angle is implied by the (depth, height) pair:
+ *          atan((height - _tab_support_height) / depth).
+ * @param depth How deep the tab protrudes into the bin.
+ * @param height Total vertical extent of the tab. Defaults to the height
+ *               that keeps the ramp at `_tab_support_angle`.
+ */
+function tab_polygon(depth=_tab_depth, height=undef) =
+    let(h = is_undef(height) ? default_tab_height(depth) : height)
+    [
+        [0, 0],
+        [0, h],
+        [depth, h],
+        [depth, h - _tab_support_height]
+    ];
+
 // ****************************************
 // Stacking Lip Constants
 // Based on https://gridfinity.xyz/specification/

--- a/src/core/tab.scad
+++ b/src/core/tab.scad
@@ -15,14 +15,22 @@ use <../helpers/grid_element.scad>
  *          Aka +X axis.
  *          Angled so the base is touching the origin.
  * @param width How wide the tab is.
+ * @param depth How deep the tab protrudes into the bin.
+ *              Defaults to the library-standard depth.
+ * @param height Total vertical extent of the tab.
+ *               Defaults to the height that keeps the support ramp at the
+ *               library-standard overhang angle.
  */
-module tab(width = TAB_WIDTH_NOMINAL){
+module tab(width = TAB_WIDTH_NOMINAL, depth = _tab_depth, height = undef){
     assert(is_num(width) && width > 0);
+    assert(is_num(depth) && depth > 0);
+    resolved_height = is_undef(height) ? default_tab_height(depth) : height;
+    assert(is_num(resolved_height) && resolved_height > _tab_support_height);
 
     translate([0, width / 2, 0])
     rotate([90, 0, 00])
     linear_extrude(width)
-    polygon(TAB_POLYGON);
+    polygon(tab_polygon(depth, resolved_height));
 }
 
 /*


### PR DESCRIPTION

Addresses #153.

The rebuilt-2 rewrite fixed the label tab at `TAB_WIDTH_NOMINAL` and a constant `TAB_POLYGON` baked from `_tab_depth` / `_tab_support_angle` at module-load time. That's fine for the customizer, but awkward when calling the modules directly: short bins want shorter tabs, narrow compartments want narrower tabs, and there's no knob for the overhang ramp dimensions at all.

| Baseline | `tab_width=25` | `tab_depth=8` | `tab_height=5` | `tab_height_from_angle(_tab_depth, 20)` |
|:---:|:---:|:---:|:---:|:---:|
| ![](https://raw.githubusercontent.com/jaehho/gridfinity-rebuilt-openscad/pr-assets/example_1.png) | ![](https://raw.githubusercontent.com/jaehho/gridfinity-rebuilt-openscad/pr-assets/example_2.png) | ![](https://raw.githubusercontent.com/jaehho/gridfinity-rebuilt-openscad/pr-assets/example_3.png) | ![](https://raw.githubusercontent.com/jaehho/gridfinity-rebuilt-openscad/pr-assets/example_4.png) | ![](https://raw.githubusercontent.com/jaehho/gridfinity-rebuilt-openscad/pr-assets/example_5.png) |

Each image is an isolated render of the `tab()` module attached to a representative wall segment (the blue plate stands for the bin's inner wall). All three dimensions - width along the wall, depth into the compartment, and vertical height with the underside ramp - are visible per example.

## API additions

All on `cut_compartment_auto`, `compartment_cutter`, `_compartment_tab`, and `tab()` (width only on the first two; the inner modules already accepted it):

| Parameter    | Controls                                         | Default                                    |
|--------------|--------------------------------------------------|--------------------------------------------|
| `tab_width`  | tab extent along the wall                        | `TAB_WIDTH_NOMINAL` (42 mm)                |
| `tab_depth`  | how far the tab juts into the compartment        | `_tab_depth` (15.85 mm)                    |
| `tab_height` | total vertical extent of the tab                 | `default_tab_height(tab_depth)`            |

Every default matches the previously-hardcoded constant, so existing renders are bit-identical.

## Helper functions in `standard.scad`

    function default_tab_height(depth=_tab_depth);
    function tab_height_from_angle(depth, angle);
    function tab_polygon(depth=_tab_depth, height=undef);

`tab_height_from_angle` is for callers who prefer to reason about the print-overhang angle rather than the tab's absolute dimensions. The support ramp is implicitly defined by the `(depth, height)` pair: `angle = atan((height - _tab_support_height) / depth)`.

![three tab cross-sections at different heights](https://raw.githubusercontent.com/jaehho/gridfinity-rebuilt-openscad/pr-assets/profile.png)

*Left→right: default (~36° ramp, steelblue) · `tab_height=5` (~13° ramp, coral) · `tab_height_from_angle(depth, 20)` (20° ramp, seagreen)*

## Usage

    // Shorter tab for shallow bins
    cut_compartment_auto(cgs(), 1, false, 0, tab_height=5);

    // Narrower tab when the compartment is small
    cut_compartment_auto(cgs(), 1, false, 0, tab_width=25);

    // Shallower inward protrusion
    cut_compartment_auto(cgs(), 1, false, 0, tab_depth=8);

    // Pick by overhang angle instead of height
    cut_compartment_auto(cgs(), 1, false, 0,
        tab_height=tab_height_from_angle(_tab_depth, 30));

## Backwards compatibility

* `TAB_POLYGON`, `TAB_SIZE`, `_tab_height`, and the `d_tabh` alias are unchanged — any external code importing them sees identical values.
* No changes to the customizer-level `.scad` files (per the API-minimalism steer on #153). Advanced tab tuning stays in the modular API.
* Every existing in-repo call site (`gridfinity-rebuilt-bins.scad`, `gridfinity-rebuilt-lite.scad`, the `cutouts.scad` examples) uses only the old positional signatures; rendered output is unchanged.

## Test plan

- [x] Rendered the hero and profile images above against this branch. All five parameter overrides produce the requested tab geometry.
- [x] Rendered the existing `gridfinity-rebuilt-bins.scad` with default arguments — output is bit-identical to `main`.
- [x] Pre-commit hooks (`trailing-whitespace`, `end-of-file-fixer`, `fix-byte-order-marker`, `check-json`, `check-yaml`) pass locally; CI only runs pre-commit.

